### PR TITLE
Fix network module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(xtd)
 enable_testing()
 set(PROJECT_VERSION_MAJOR 0)
 set(PROJECT_VERSION_MINOR 1)
-set(PROJECT_VERSION_PATCH 1)
+set(PROJECT_VERSION_PATCH 2)
 
 # ---------
 # libraries
@@ -82,7 +82,7 @@ endif()
 enable_tracking()
 
 set(CMAKE_CXX_COMPILER         "g++")
-set(CMAKE_CXX_FLAGS            "${CMAKE_CXX_FLAGS} -std=gnu++11 -W -Wall -Wextra")
+set(CMAKE_CXX_FLAGS            "${CMAKE_CXX_FLAGS} -std=gnu++11 -W -Wall -Wextra -Werror")
 set(CMAKE_CXX_FLAGS_DEBUG      "${CMAKE_CXX_FLAGS_DEBUG} -O0 -fprofile-arcs -ftest-coverage")
 set(CMAKE_CXX_FLAGS_RELEASE    "${CMAKE_CXX_FLAGS_RELEASE} -Werror")
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -39,7 +39,7 @@ add_cloc(core)
 add_cppcheck(core)
 add_check(core
   INCLUDES ${core_INCLUDE_DIRS} ${tests_INCLUDE_DIRS}
-  LINKS    cwrap core_s tests_s)
+  LINKS    cwrap tests_s core_s)
 add_cov(core)
 add_memcheck(core)
 

--- a/core/src/log/ConfLoader.cc
+++ b/core/src/log/ConfLoader.cc
@@ -102,7 +102,7 @@ ConfLoader::createLogger(const string&              p_name,
   if (false == is_valid(boost::to_lower_copy(l_parts[0])))
     log::raise<log_error>("core.log", "invalid log level value '%s'", l_parts[0], HERE);
 
-  l_level = from(l_parts[0]);
+  l_level = from(boost::to_lower_copy(l_parts[0]));
   std::copy(l_parts.begin() + 1, l_parts.end(), std::back_inserter(l_appenders));
 
   Logger* l_logger = &p_root;

--- a/core/src/log/SyslogAppender.cc
+++ b/core/src/log/SyslogAppender.cc
@@ -119,9 +119,6 @@ SyslogAppender::create(const string& p_name, const map<string,string>& p_propert
   if (p_properties.end() != c_identity)
     l_identity = c_identity->second;
 
-  if (p_properties.end() == c_options)
-    log::raise<log_error>("core.log", "unable to find key 'log.appender.%s.options'", p_name, HERE);
-
   if (p_properties.end() == c_facility)
     log::raise<log_error>("core.log", "unable to find key 'log.appender.%s.facility'", p_name, HERE);
 

--- a/core/src/mixins/singleton.hh
+++ b/core/src/mixins/singleton.hh
@@ -1,6 +1,7 @@
 #pragma once
 # include <memory>
 # include <mutex>
+# include <iostream>
 
 namespace xtd {
 
@@ -53,9 +54,16 @@ public:
   static TClass& get(Args... p_args)
   {
     std::lock_guard<std::mutex> l_lock(ms_mutex);
-    if (nullptr == ms_instance.get())
+    if (nullptr == ms_instance.get()) {
       ms_instance.reset(new TClass(p_args...));
+    }
     return *ms_instance;
+  }
+
+  static void destroy(void)
+  {
+    std::lock_guard<std::mutex> l_lock(ms_mutex);
+    ms_instance.reset();
   }
 
 protected:

--- a/core/src/mixins/singleton.hh
+++ b/core/src/mixins/singleton.hh
@@ -1,5 +1,6 @@
 #pragma once
-#include <memory>
+# include <memory>
+# include <mutex>
 
 namespace xtd {
 
@@ -51,13 +52,16 @@ public:
   template<typename ... Args>
   static TClass& get(Args... p_args)
   {
+    std::lock_guard<std::mutex> l_lock(ms_mutex);
     if (nullptr == ms_instance.get())
       ms_instance.reset(new TClass(p_args...));
     return *ms_instance;
   }
 
 protected:
+public:
   static std::shared_ptr<TClass> ms_instance;
+  static std::mutex              ms_mutex;
 };
 
 /**
@@ -65,6 +69,12 @@ protected:
  */
 template<class TClass>
 std::shared_ptr<TClass> Singleton<TClass>::ms_instance;
+
+/**
+ ** @brief Mutex static instance
+ */
+template<class TClass>
+std::mutex Singleton<TClass>::ms_mutex;
 
 }}
 

--- a/core/src/text.cc
+++ b/core/src/text.cc
@@ -1,6 +1,10 @@
 #include "text.hh"
 #include <boost/assign.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/regex.hpp>
+#include <boost/algorithm/string/regex_find_format.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include "format.hh"
 
 namespace xtd {
 namespace text {
@@ -33,6 +37,47 @@ xml::encode_copy(const string& p_str)
 {
   string l_value = p_str;
   encode(l_value);
+  return l_value;
+}
+
+
+
+template<typename T>
+string
+url::hex_to_string::operator()(const T& p_match) const
+{
+  stringstream  l_value;
+  int           l_intVal;
+  unsigned char l_result;
+  l_value << std::hex << p_match.match_results().str(1);
+  l_value >> l_intVal;
+  l_result = l_intVal;
+  return format::vargs("%c", l_result);
+}
+
+
+string
+url::decode_copy(const string& p_value)
+{
+  string       l_value(p_value);
+  boost::regex l_hexRegex("%([0-9a-fA-F]{2})");
+  boost::regex l_spaceRegex("[ \t]{2,}");
+
+  // replace all + by space
+  boost::replace_all(l_value, "+", " ");
+
+  // replace hex value by corresponding character
+  boost::smatch l_match;
+  boost::algorithm::find_format_all(l_value,
+                                    boost::algorithm::regex_finder(l_hexRegex),
+                                    hex_to_string());
+
+  // remove duplicate spaces
+  boost::algorithm::find_format_all(l_value,
+                                    boost::algorithm::regex_finder(l_spaceRegex),
+                                    boost::algorithm::const_formatter(" "));
+  boost::trim(l_value);
+
   return l_value;
 }
 

--- a/core/src/text.hh
+++ b/core/src/text.hh
@@ -3,7 +3,6 @@
 # include <boost/tuple/tuple.hpp>
 # include "types.hh"
 
-
 namespace xtd {
 
 /**
@@ -49,6 +48,21 @@ private:
 private:
   static t_data ms_entityList;
 };
+
+
+class url
+{
+private:
+  struct hex_to_string
+  {
+    template<typename T>
+    string operator()(const T& p_match) const;
+  };
+
+public:
+  static string decode_copy(const string& p_value);
+};
+
 
 }}
 

--- a/core/unit/log/TestSyslogAppender.cc
+++ b/core/unit/log/TestSyslogAppender.cc
@@ -54,25 +54,25 @@ TestSyslogAppender::constructor(void)
   CWrap::hook_state l_state1("openlog",  l_onOpen);
   CWrap::hook_state l_state2("closelog", l_onClose);
 
-  CPPUNIT_ASSERT_EQUAL(0u, SyslogAppender::ms_instances);
+  CPPUNIT_ASSERT_EQUAL(1u, SyslogAppender::ms_instances);
   {
     SyslogAppender l_i1("name", LOG_PID, LOG_LOCAL0);
-    CPPUNIT_ASSERT_EQUAL(1u, SyslogAppender::ms_instances);
-    CPPUNIT_ASSERT_EQUAL(1u, l_open);
+    CPPUNIT_ASSERT_EQUAL(2u, SyslogAppender::ms_instances);
+    CPPUNIT_ASSERT_EQUAL(0u, l_open);
     CPPUNIT_ASSERT_EQUAL(0u, l_close);
     {
       SyslogAppender l_i2("name", LOG_PID, LOG_LOCAL0);
-      CPPUNIT_ASSERT_EQUAL(2u, SyslogAppender::ms_instances);
-      CPPUNIT_ASSERT_EQUAL(1u, l_open);
+      CPPUNIT_ASSERT_EQUAL(3u, SyslogAppender::ms_instances);
+      CPPUNIT_ASSERT_EQUAL(0u, l_open);
       CPPUNIT_ASSERT_EQUAL(0u, l_close);
     }
-    CPPUNIT_ASSERT_EQUAL(1u, SyslogAppender::ms_instances);
-    CPPUNIT_ASSERT_EQUAL(1u, l_open);
+    CPPUNIT_ASSERT_EQUAL(2u, SyslogAppender::ms_instances);
+    CPPUNIT_ASSERT_EQUAL(0u, l_open);
     CPPUNIT_ASSERT_EQUAL(0u, l_close);
   }
-  CPPUNIT_ASSERT_EQUAL(0u, SyslogAppender::ms_instances);
-  CPPUNIT_ASSERT_EQUAL(1u, l_open);
-  CPPUNIT_ASSERT_EQUAL(1u, l_close);
+  CPPUNIT_ASSERT_EQUAL(1u, SyslogAppender::ms_instances);
+  CPPUNIT_ASSERT_EQUAL(0u, l_open);
+  CPPUNIT_ASSERT_EQUAL(0u, l_close);
 }
 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,35 @@
+xtdcpp (1.0.2ppa1~xenial) xenial; urgency=medium
+
+  * [network/http] fixes #19 : boost and std shared_pointer are no longer mixed
+  * [network/http] fixes #20 : server replies with correct keepalive heaver
+  * [network/http] implements http client
+  * [network/http] get rid of ugly filter and handler structures replaced by c++11 variadic template args
+  * [network] replace many boost call to c++11 std
+  * [core] log config loader parses log_level case insensitively
+  * [core] log syslogappender no longer require options config property
+  * [core] moved url decode function to core text::url
+  * [tests] enable debug syslog logs in main test application
+  * [tests] adds handy "exec" function to default test fixture class
+  * xtdmake : bump version
+
+ -- Xavier MARCELET <xavier@marcelet.com>  Sun, 15 Jan 2017 03:30:00 +0100
+
+xtdcpp (1.0.2ppa1~trusty) trusty; urgency=medium
+
+  * [network/http] fixes #19 : boost and std shared_pointer are no longer mixed
+  * [network/http] fixes #20 : server replies with correct keepalive heaver
+  * [network/http] implements http client
+  * [network/http] get rid of ugly filter and handler structures replaced by c++11 variadic template args
+  * [network] replace many boost call to c++11 std
+  * [core] log config loader parses log_level case insensitively
+  * [core] log syslogappender no longer require options config property
+  * [core] moved url decode function to core text::url
+  * [tests] enable debug syslog logs in main test application
+  * [tests] adds handy "exec" function to default test fixture class
+  * xtdmake : bump version
+
+ -- Xavier MARCELET <xavier@marcelet.com>  Sun, 15 Jan 2017 03:30:00 +0100
+
 xtdcpp (1.0.1ppa1~xenial) xenial; urgency=medium
 
   * catch up xtdmake new release 1.0.3

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,12 @@
-xtdcpp (1.0.2ppa1~xenial) xenial; urgency=medium
+xtdcpp (1.0.2ppa3~xenial) xenial; urgency=medium
 
   * [network/http] fixes #19 : boost and std shared_pointer are no longer mixed
   * [network/http] fixes #20 : server replies with correct keepalive heaver
   * [network/http] implements http client
   * [network/http] get rid of ugly filter and handler structures replaced by c++11 variadic template args
   * [network] replace many boost call to c++11 std
+  * [network] replace ThreadManager singleton by core mixin
+  * [network] fix ThreadManager destruction race condition
   * [core] log config loader parses log_level case insensitively
   * [core] log syslogappender no longer require options config property
   * [core] moved url decode function to core text::url
@@ -12,15 +14,18 @@ xtdcpp (1.0.2ppa1~xenial) xenial; urgency=medium
   * [tests] adds handy "exec" function to default test fixture class
   * xtdmake : bump version
 
+
  -- Xavier MARCELET <xavier@marcelet.com>  Sun, 15 Jan 2017 03:30:00 +0100
 
-xtdcpp (1.0.2ppa1~trusty) trusty; urgency=medium
+xtdcpp (1.0.2ppa3~trusty) trusty; urgency=medium
 
   * [network/http] fixes #19 : boost and std shared_pointer are no longer mixed
   * [network/http] fixes #20 : server replies with correct keepalive heaver
   * [network/http] implements http client
   * [network/http] get rid of ugly filter and handler structures replaced by c++11 variadic template args
   * [network] replace many boost call to c++11 std
+  * [network] replace ThreadManager singleton by core mixin
+  * [network] fix ThreadManager destruction race condition
   * [core] log config loader parses log_level case insensitively
   * [core] log syslogappender no longer require options config property
   * [core] moved url decode function to core text::url

--- a/network/CMakeLists.txt
+++ b/network/CMakeLists.txt
@@ -19,11 +19,14 @@ add_shared_static_library(network
   src/bip/Connection.cc
   src/http/Server.cc
   src/http/Connection.cc
+  src/http/Message.cc
   src/http/Request.cc
   src/http/Response.cc
   src/http/Template.cc
   src/http/Server.cc
+  src/http/Client.cc
   src/http/cpptempl.cc
+  src/http/types.cc
 )
 
 
@@ -35,6 +38,6 @@ add_cppcheck(network)
 add_check(network
   ARGS     -p -o compiler
   INCLUDES ${core_INCLUDE_DIRS} ${network_INCLUDE_DIRS} ${tests_INCLUDE_DIRS}
-  LINKS    core_s tests_s network_s ${Boost_LIBRARIES})
+  LINKS      network_s tests_s core_s ${Boost_LIBRARIES})
 add_cov(network)
 add_memcheck(network)

--- a/network/src/base/Client.hxx
+++ b/network/src/base/Client.hxx
@@ -19,8 +19,6 @@ namespace base {
  ** ce header prive et l'instanciation explicite par Client.cc
  */
 
-using namespace boost;
-
 namespace ba = boost::asio;
 namespace bs = boost::system;
 
@@ -80,7 +78,7 @@ Client<Domain>::async_connect(const string&  p_hostname,
 
   m_connection = createCnx(m_hostname, m_port);
   m_connection->connect(m_resolver,
-                        boost::bind(&Client::onConnected, this, _1));
+                        std::bind(&Client::onConnected, this, std::placeholders::_1));
 
   log::debug("network.base.client", "async_connect (%s:%d) : leaving", p_hostname, p_port, HERE);
 }
@@ -115,7 +113,7 @@ void
 Client<Domain>::onConnected(const bs::error_code p_error)
 {
   // On libere la semaphore juste a la sortie de la fonction pour garantir l'exitence de la connection
-  utils::scoped_method l_semPos(boost::bind(&boost::interprocess::interprocess_semaphore::post, boost::ref(m_semaphoreConnect)));
+  utils::scoped_method l_semPos(std::bind(&boost::interprocess::interprocess_semaphore::post, std::ref(m_semaphoreConnect)));
 
   log::info("network.base.client", "onConnected (%s) : entering", m_connection->info(), HERE);
 

--- a/network/src/base/Client.hxx
+++ b/network/src/base/Client.hxx
@@ -26,7 +26,7 @@ namespace bs = boost::system;
 
 template <typename Domain>
 Client<Domain>::Client(const utils::Config& p_conf) :
-  m_threadManager(ThreadManager::getInstance()),
+  m_threadManager(ThreadManager::get()),
   m_resolver(),
   m_hostname(),
   m_port(),

--- a/network/src/base/ClientThreadManager.cc
+++ b/network/src/base/ClientThreadManager.cc
@@ -14,7 +14,7 @@ ThreadManager::ThreadManager(void)
 {
   m_ioService = new boost::asio::io_service;
   m_workPtr.reset(new boost::asio::io_service::work(*m_ioService));
-  m_threadPtr.reset(new std::thread([m_ioService](void) { m_ioService->run(); }));
+  m_threadPtr.reset(new std::thread([this](void) { m_ioService->run(); }));
 }
 
 
@@ -35,7 +35,7 @@ ThreadManager::createThread(const size_t p_threadId)
   threadMap_t::iterator l_threadMapIt = m_threadMap.find(p_threadId);
   if (l_threadMapIt == m_threadMap.end())
   {
-    m_threadMap[p_threadId] = std::make_shared<std::thread>([m_ioService](void) {
+    m_threadMap[p_threadId] = std::make_shared<std::thread>([this](void) {
         m_ioService->run();
       });
   }

--- a/network/src/base/ClientThreadManager.cc
+++ b/network/src/base/ClientThreadManager.cc
@@ -1,38 +1,40 @@
 #include "base/ClientThreadManager.hh"
 #include <functional>
-
+#include <iostream>
 namespace xtd {
 namespace network {
 namespace base {
 
-std::mutex                ThreadManager::m_mutex;
-boost::asio::io_service*  ThreadManager::m_ioService     = 0;
-ThreadManager*            ThreadManager::m_threadManager = 0;
 
-
-ThreadManager::ThreadManager(void)
+ThreadManager::ThreadManager(void) :
+  m_ioService(),
+  m_work(),
+  m_thread(),
+  m_threadMap()
 {
-  m_ioService = new boost::asio::io_service;
-  m_workPtr.reset(new boost::asio::io_service::work(*m_ioService));
-  m_threadPtr.reset(new std::thread([this](void) { m_ioService->run(); }));
+  m_ioService.reset(new boost::asio::io_service());
+  m_work.reset(new boost::asio::io_service::work(*m_ioService));
+  m_thread.reset(new std::thread([this](void) { m_ioService->run(); }));
 }
 
 
 ThreadManager::~ThreadManager(void)
 {
-  m_workPtr.reset();
-  threadMap_t::iterator l_threadMapIt = m_threadMap.begin();
-  while (l_threadMapIt != m_threadMap.end())
-  {
-    (l_threadMapIt->second)->join();
+  m_work.reset();
+  for (auto& c_thread : m_threadMap) {
+    c_thread.second->join();
   }
+  m_threadMap.clear();
+  m_thread->join();
+  m_thread.reset();
+  m_ioService.reset();
 }
 
 
 void
 ThreadManager::createThread(const size_t p_threadId)
 {
-  threadMap_t::iterator l_threadMapIt = m_threadMap.find(p_threadId);
+  t_map::iterator l_threadMapIt = m_threadMap.find(p_threadId);
   if (l_threadMapIt == m_threadMap.end())
   {
     m_threadMap[p_threadId] = std::make_shared<std::thread>([this](void) {
@@ -41,23 +43,11 @@ ThreadManager::createThread(const size_t p_threadId)
   }
 }
 
-
 boost::asio::io_service&
 ThreadManager::getIoService(void)
 {
   return *m_ioService;
 }
 
-
-ThreadManager&
-ThreadManager::getInstance(void)
-{
-  std::lock_guard<std::mutex> l_lock(m_mutex);
-  if (!m_threadManager)
-  {
-    m_threadManager = new ThreadManager();
-  }
-  return *m_threadManager;
-}
 
 }}} // end namespace

--- a/network/src/base/ClientThreadManager.hh
+++ b/network/src/base/ClientThreadManager.hh
@@ -2,24 +2,23 @@
 # define NETWORK_BASE_CLIENTTHREADMANAGER_HH_
 
 # include <boost/asio.hpp>
-# include <boost/thread.hpp>
-# include <boost/thread/mutex.hpp>
-# include <boost/noncopyable.hpp>
+# include <mutex>
+# include <thread>
 # include <memory>
-# include <boost/make_shared.hpp>
 # include <types.hh> //libcore
 
 namespace xtd {
 namespace network {
 namespace base {
 
-class ThreadManager : boost::noncopyable
+class ThreadManager
 {
 public:
-  typedef map<size_t, std::shared_ptr<boost::thread> > threadMap_t;
+  typedef map<size_t, std::shared_ptr<std::thread> > threadMap_t;
 
 private:
   ThreadManager(void);
+  ThreadManager(const ThreadManager&) = delete;
   ~ThreadManager(void);
 
 public:
@@ -30,12 +29,12 @@ public:
 private:
   // Attention à l'initialisation d'un pointeur static lors des tests unitaires qui cachent un fork
   // pour garantir l'ordre d'initialisation, création du pointeur au constructeur
-  static boost::asio::io_service*                  m_ioService;
-  static boost::mutex                              m_mutex;
-  static ThreadManager*                            m_threadManager;
+  static boost::asio::io_service*                m_ioService;
+  static std::mutex                              m_mutex;
+  static ThreadManager*                          m_threadManager;
   std::shared_ptr<boost::asio::io_service::work> m_workPtr;
-  threadMap_t                                      m_threadMap;
-  std::shared_ptr<boost::thread>                 m_threadPtr;
+  threadMap_t                                    m_threadMap;
+  std::shared_ptr<std::thread>                   m_threadPtr;
 };
 
 }}} // end namespaces

--- a/network/src/base/ClientThreadManager.hh
+++ b/network/src/base/ClientThreadManager.hh
@@ -6,35 +6,37 @@
 # include <thread>
 # include <memory>
 # include <types.hh> //libcore
+# include <mixins/singleton.hh> // libcore
 
 namespace xtd {
 namespace network {
 namespace base {
 
-class ThreadManager
+class ThreadManager : public mixins::Singleton<ThreadManager>
 {
-public:
-  typedef map<size_t, std::shared_ptr<std::thread> > threadMap_t;
+  friend class mixins::Singleton<ThreadManager>;
 
-private:
+public:
+  typedef map<size_t, sptr<std::thread> > t_map;
+
+protected:
   ThreadManager(void);
   ThreadManager(const ThreadManager&) = delete;
-  ~ThreadManager(void);
 
 public:
-  static ThreadManager&    getInstance(void);
+  virtual ~ThreadManager(void);
+
+public:
   void                     createThread(const size_t p_threadId);
   boost::asio::io_service& getIoService(void);
 
 private:
   // Attention à l'initialisation d'un pointeur static lors des tests unitaires qui cachent un fork
   // pour garantir l'ordre d'initialisation, création du pointeur au constructeur
-  static boost::asio::io_service*                m_ioService;
-  static std::mutex                              m_mutex;
-  static ThreadManager*                          m_threadManager;
-  std::shared_ptr<boost::asio::io_service::work> m_workPtr;
-  threadMap_t                                    m_threadMap;
-  std::shared_ptr<std::thread>                   m_threadPtr;
+  sptr<boost::asio::io_service>       m_ioService;
+  sptr<boost::asio::io_service::work> m_work;
+  sptr<std::thread>                   m_thread;
+  t_map                               m_threadMap;
 };
 
 }}} // end namespaces

--- a/network/src/base/Connection.hh
+++ b/network/src/base/Connection.hh
@@ -54,8 +54,7 @@ namespace base {
  **     effective de la socket)
  */
 template <typename Domain>
-class Connection : public boost::enable_shared_from_this<Connection<Domain> >,
-                   public boost::noncopyable
+class Connection : public std::enable_shared_from_this<Connection<Domain> >
 {
 public:
   /** @brief shared_ptr sur this */
@@ -63,17 +62,19 @@ public:
 
 protected:
   // 1.
-  explicit Connection(const utils::Config& p_configuration,
-                      boost::asio::io_service&                p_ioService,
-                      const string                            p_hostname,
-                      const uint32_t                          p_port);
+  explicit Connection(const utils::Config&     p_configuration,
+                      boost::asio::io_service& p_ioService,
+                      const string             p_hostname,
+                      const uint32_t           p_port);
+
+  Connection(const Connection&) = delete;
 
 public:
   /** @brief descruteur */
   virtual ~Connection(void);
 
 public:
-  inline void         setProcessID(uint32_t p_procesID);
+  inline void     setProcessID(uint32_t p_procesID);
   inline uint32_t getProcessID(void) const;
 
 public:
@@ -87,7 +88,7 @@ public:
    ** enregistré l'évenement.
    */
   void accept(std::shared_ptr<boost::asio::basic_socket_acceptor<Domain> > p_acceptor,
-              utils::handler_t                                               p_onAccepted);
+              utils::handler_t                                             p_onAccepted);
 
   /**
    ** @brief connexion aynchrone de socket (client only)
@@ -135,16 +136,16 @@ public:
 
 private:
   void do_accept(std::shared_ptr<boost::asio::basic_socket_acceptor<Domain> > p_acceptor,
-                 utils::handler_t                                               p_onAccepted);
+                 utils::handler_t                                             p_onAccepted);
   /**
    ** @details
    ** L'acceptor est gardé jusqu'à l'exécution de la callback pour
    ** garantir sa durée de vie dans le cas où un utilisateur peu clairvoyant
    ** ait décidé d'instancier un acceptor pour chaque connection...)
    */
-  void onAccepted(boost::system::error_code                                      p_error,
+  void onAccepted(boost::system::error_code                                    p_error,
                   std::shared_ptr<boost::asio::basic_socket_acceptor<Domain> > p_acceptor,
-                  utils::handler_t                                               p_onAccepted);
+                  utils::handler_t                                             p_onAccepted);
 
 
   /* connextion  */
@@ -157,27 +158,27 @@ private:
   void do_connect(std::shared_ptr<utils::Resolver<Domain> > p_resolver,
                   utils::handler_t                            p_onConnected);
   void connectTimeout(const boost::system::error_code p_error);
-  void onConnected(const boost::system::error_code           p_error,
+  void onConnected(const boost::system::error_code         p_error,
                    std::shared_ptr<utils::deadLineTimer_t> p_timer,
-                   utils::handler_t                          p_onConnected);
+                   utils::handler_t                        p_onConnected);
 
   /* envoi */
   void do_send(utils::sharedBuf_t p_outData,
                utils::handler_t   p_onSent);
   void sendTimeout(const boost::system::error_code p_error);
-  void onSent(const boost::system::error_code           p_error,
-              utils::sharedBuf_t                        p_outData,
+  void onSent(const boost::system::error_code         p_error,
+              utils::sharedBuf_t                      p_outData,
               std::shared_ptr<utils::deadLineTimer_t> p_timer,
-              utils::handler_t                          p_onSent);
+              utils::handler_t                        p_onSent);
 
 
   /* reception */
   void do_receive(utils::sharedBuf_t p_inData,
                   utils::handler_t   p_onReceived);
   void receiveTimeout(const boost::system::error_code p_error);
-  void onReceived(const boost::system::error_code           p_error,
+  void onReceived(const boost::system::error_code         p_error,
                   std::shared_ptr<utils::deadLineTimer_t> p_timer,
-                  utils::handler_t                          p_onReceived);
+                  utils::handler_t                        p_onReceived);
 
   /**
    ** @details

--- a/network/src/base/Server.hh
+++ b/network/src/base/Server.hh
@@ -1,7 +1,6 @@
 #ifndef NETWORK_BASE_SERVER_HH_
 # define NETWORK_BASE_SERVER_HH_
 
-# include <boost/noncopyable.hpp>
 # include "utils/Config.hh"
 # include "utils/CommTypeDefs.hh"
 # include "utils/Utils.hh"
@@ -27,13 +26,14 @@ template<typename D> class Connection;
  **    ce qui garantie la duree de vie de l'objet
  */
 template <typename Domain>
-class Server : private boost::noncopyable
+class Server
 {
 protected:
   typedef typename std::shared_ptr<Connection<Domain> > cnx_sptr_t;
 
 public:
   Server(void);
+  Server(const Server&) = delete;
   virtual ~Server(void);
 
 
@@ -69,6 +69,14 @@ public:
    ** @brief Annule tout les operations en cours et coupe les threads
    */
   virtual void stop(void);
+
+  /**
+   ** @brief Returns the associated port
+   ** @details
+   ** When initializing with port 0, system automatically find an available port.
+   ** This method returns which port was actually used.
+   */
+  const typename Domain::endpoint getEndPoint(void) const;
 
 
 
@@ -127,16 +135,16 @@ protected:
   inline uint32_t& getCnxRejected(void);
 
 protected:
-  utils::Config                               m_conf;
-  utils::deque_id<uint32_t>                                  m_dequeId;
-  utils::ioServicePtr_t                                          m_ioService;
-  utils::workPtr_t                                               m_work;
+  utils::Config                                                m_conf;
+  utils::deque_id<uint32_t>                                    m_dequeId;
+  utils::ioServicePtr_t                                        m_ioService;
+  utils::workPtr_t                                             m_work;
   std::shared_ptr<boost::asio::basic_socket_acceptor<Domain> > m_acceptor;
 
 private:
   std::shared_ptr<utils::Resolver<Domain> > m_resolver;
-  size_t                                 m_threadNb;
-  boost::thread_group                         m_threadGroup;
+  size_t                                    m_threadNb;
+  boost::thread_group                       m_threadGroup;
   // counters
   uint32_t m_nbCurrentThread;
   uint32_t m_cnxTotal;

--- a/network/src/bip/Client.hh
+++ b/network/src/bip/Client.hh
@@ -5,7 +5,6 @@
 
 namespace xtd {
 namespace network {
-
 namespace bip {
 
 /**
@@ -41,34 +40,11 @@ public:
 private:
   typedef base::Client<TDomain>      TBase;
   typedef typename TBase::cnx_sptr_t cnx_sptr_t;
-
-  /**
-   ** @brief Code pour l'état du client
-   */
-  enum class cnxstatus : int32_t
-  {
-    available = 0, /**< pret à envoyer une nouvelle requête (nouveau send) */
-      reserved  = 1, /**< requête en cours d'envoi sur le réseau */
-      sent      = 2, /**< requête envoyé, en attente de réception réseau de la réponse */
-      received  = 3, /**< réponse réseau reçue, en attente de l'appel à client à receive */
-      error     = 4, /**< envoi ou reception réseau en timeout, en attente d'un appel client à receive */
-      timeout   = 5  /**< envoi ou reception réseau en erreur, en attente d'un appel client à receive */
-      };
+  typedef typename TBase::cnxstatus  cnxstatus;
 
 public:
   Client(const utils::Config& p_conf);
   virtual ~Client(void);
-
-public:
-  inline const uint32_t& getSendTotal(void) const       { return m_sendTotal; }
-  inline const uint32_t& getSendSuccess(void) const     { return m_sendSuccess; }
-  inline const uint32_t& getSendTimeout(void) const     { return m_sendTimeout; }
-  inline const uint32_t& getSendError(void) const       { return m_sendError; }
-  inline const uint32_t& getReceiveTotal(void) const    { return m_receiveTotal; }
-  inline const uint32_t& getReceiveSuccess(void) const  { return m_receiveSuccess; }
-  inline const uint32_t& getReceiveTimeout(void) const  { return m_receiveTimeout; }
-  inline const uint32_t& getReceiveError(void) const    { return m_receiveError; }
-  inline const uint32_t& getLastRTTMs(void) const       { return m_lastRTTMs; }
 
 public:
   /**
@@ -109,15 +85,6 @@ private:
   cnxstatus                                   m_status;
   utils::vectorBytes_t                        m_response;
   boost::posix_time::ptime                    m_lastSend;
-  uint32_t                                    m_sendTotal;
-  uint32_t                                    m_sendError;
-  uint32_t                                    m_sendSuccess;
-  uint32_t                                    m_sendTimeout;
-  uint32_t                                    m_receiveTotal;
-  uint32_t                                    m_receiveError;
-  uint32_t                                    m_receiveTimeout;
-  uint32_t                                    m_receiveSuccess;
-  uint32_t                                    m_lastRTTMs;
 };
 
 }}} //end namespaces

--- a/network/src/bip/ClientPool.hh
+++ b/network/src/bip/ClientPool.hh
@@ -97,11 +97,11 @@ public:
   void release(t_client_sptr& p_client);
 
 private:
-  boost::mutex       m_mutex;
-  t_pool             m_available;
-  const string  m_hostname;
-  const uint32_t m_port;
-  const uint32_t m_ttlMs;
+  std::mutex          m_mutex;
+  t_pool              m_available;
+  const string        m_hostname;
+  const uint32_t      m_port;
+  const uint32_t      m_ttlMs;
   const utils::Config m_conf;
 
 private:

--- a/network/src/bip/ClientPool.hxx
+++ b/network/src/bip/ClientPool.hxx
@@ -167,11 +167,11 @@ template<class TRequest, class TResponse, typename TDomain>
 typename ClientPool<TRequest, TResponse, TDomain>::t_client_sptr
 ClientPool<TRequest, TResponse, TDomain>::acquire(void)
 {
-  boost::mutex::scoped_lock l_lock(m_mutex);
-  t_client_sptr             l_obj;
+  std::lock_guard<std::mutex> l_lock(m_mutex);
+  t_client_sptr               l_obj;
 
   // 1.
-  m_available.erase(std::remove_if(m_available.begin(), m_available.end(), boost::bind(&PersistentClient::isObsolete, _1, m_ttlMs)), m_available.end());
+  m_available.erase(std::remove_if(m_available.begin(), m_available.end(), std::bind(&PersistentClient::isObsolete, std::placeholders::_1, m_ttlMs)), m_available.end());
 
   if (false == m_available.empty())
     m_recycleHit++;
@@ -196,7 +196,7 @@ template<class TRequest, class TResponse, typename TDomain>
 void
 ClientPool<TRequest, TResponse, TDomain>::release(t_client_sptr& p_client)
 {
-  boost::mutex::scoped_lock l_lock(m_mutex);
+  std::lock_guard<std::mutex> l_lock(m_mutex);
 
   m_available.push_front(p_client);
   m_acquiredClients  -= 1;

--- a/network/src/bip/Connection.hxx
+++ b/network/src/bip/Connection.hxx
@@ -12,15 +12,15 @@ namespace network {
 namespace bip {
 
 
-using namespace boost;
-namespace ba = asio;
-namespace bs = system;
+
+namespace ba = boost::asio;
+namespace bs = boost::system;
 
 template <typename Domain>
 Connection<Domain>::Connection(const utils::Config& p_configuration,
-                               ba::io_service&                         p_ioService,
-                               const string                       p_hostname,
-                               const uint32_t                     p_port) :
+                               ba::io_service&      p_ioService,
+                               const string         p_hostname,
+                               const uint32_t       p_port) :
   TBase(p_configuration, p_ioService, p_hostname, p_port),
   m_header(mcs_headerSize),
   m_inboundData(),
@@ -96,13 +96,13 @@ Connection<Domain>::async_write(utils::sharedBuf_t p_outData, utils::handler_t p
   // send it through the socket
   ba::async_write(this->m_socket,
                   l_buffers,
-                  boost::bind(&Connection::onSent,
-                              this,
-                              _1,
-                              _2,
-                              l_headerBuff,
-                              l_outBuff,
-                              p_onSent));
+                  std::bind(&Connection::onSent,
+                            this,
+                            std::placeholders::_1,
+                            std::placeholders::_2,
+                            l_headerBuff,
+                            l_outBuff,
+                            p_onSent));
 }
 
 
@@ -129,12 +129,12 @@ Connection<Domain>::async_read(utils::sharedBuf_t p_inData, utils::handler_t p_o
   // async read makes sure to receive all the data
   ba::async_read(this->m_socket,
                  ba::buffer(m_header),
-                 boost::bind(&Connection::onHeaderReceived,
-                             this,
-                             _1,
-                             _2,
-                             p_inData,
-                             p_onReceived));
+                 std::bind(&Connection::onHeaderReceived,
+                           this,
+                           std::placeholders::_1,
+                           std::placeholders::_2,
+                           p_inData,
+                           p_onReceived));
 
   log::debug("network.bip.cnx", "bip cnx async_read (%s) : leaving (%d)", TBase::info(), m_counter, HERE);
 }
@@ -175,10 +175,10 @@ void
 Connection<Domain>::receive_data(utils::sharedBuf_t p_inData,
                                  utils::handler_t   p_onReceived)
 {
-  TBase::m_strand.post(boost::bind(&Connection::do_receive_data,
-                                   this,
-                                   p_inData,
-                                   p_onReceived));
+  TBase::m_strand.post(std::bind(&Connection::do_receive_data,
+                                 this,
+                                 p_inData,
+                                 p_onReceived));
 }
 
 
@@ -189,12 +189,12 @@ Connection<Domain>::do_receive_data(utils::sharedBuf_t p_inData,
 {
   ba::async_read(TBase::m_socket,
                  ba::buffer(m_inboundData),
-                 boost::bind(&Connection::onDataReceived,
-                             this,
-                             _1,
-                             _2,
-                             p_inData,
-                             p_onReceived));
+                 std::bind(&Connection::onDataReceived,
+                           this,
+                           std::placeholders::_1,
+                           std::placeholders::_2,
+                           p_inData,
+                           p_onReceived));
 }
 
 

--- a/network/src/http/Client.cc
+++ b/network/src/http/Client.cc
@@ -1,0 +1,11 @@
+#include "http/Client.hh"
+#include "http/Client.hxx"
+
+namespace xtd {
+namespace network {
+namespace http {
+
+template class Client<utils::af_inet>;
+template class Client<utils::af_unix>;
+
+}}}

--- a/network/src/http/Client.hh
+++ b/network/src/http/Client.hh
@@ -1,0 +1,63 @@
+#ifndef NETWORK_HTTP_CLIENT_HH_
+# define NETWORK_HTTP_CLIENT_HH_
+
+# include "base/Client.hh"
+
+namespace xtd {
+namespace network {
+namespace http {
+
+class Request;
+class Response;
+
+template<typename TDomain = utils::af_inet>
+class Client : public base::Client<TDomain>
+{
+private:
+  typedef base::Client<TDomain>      TBase;
+  typedef typename TBase::cnx_sptr_t cnx_sptr_t;
+  typedef typename TBase::cnxstatus  cnxstatus;
+
+public:
+  Client(const utils::Config& p_conf);
+  virtual ~Client(void);
+
+public:
+  /**
+   ** @brief envoi d'une structure requête au server
+   ** @param p_request la requête
+   ** @return status::ok si tout va bien, status::error sinon
+   ** @details
+   ** Non bloquant, status::ok ne veut pas dire que le message est bien arrivé,
+   ** simplement que l'objet étaient en étant d'envoyer une requête (pas
+   ** déjà en attente de réponse par exemple).
+   */
+  status send(const Request& p_request);
+
+  /**
+   ** @brief reception de la structure réponse
+   ** @param p_response structure à remplir avec la réponse du server
+   ** @return status::ok si tout va bien, status::timeout en cas de timeout et staus::error en cas d'erreur.
+   ** @details
+   ** Cette méthode est bloquante, elle attend la réception effective de la réponse
+   ** du serveur ou la survenue d'une erreur/timeout.
+   */
+  status receive(Response& p_response);
+
+private:
+  cnx_sptr_t createCnx(string p_hostname, uint32_t p_port);
+  void       do_receive(void);
+  void       onSent(const boost::system::error_code p_error);
+  void       onReceived(const boost::system::error_code p_error,
+                        utils::sharedBuf_t              p_response);
+private:
+  /** Semaphore uitilise pour bloquer l'utilisateur soit dans le send (noget) soit dans le receive */
+  boost::interprocess::interprocess_semaphore m_userSemaphore;
+  cnxstatus                                   m_status;
+  utils::vectorBytes_t                        m_response;
+  boost::posix_time::ptime                    m_lastSend;
+};
+
+}}} //end namespaces
+
+#endif // !NETWORK_HTTPCLIENT_HH_

--- a/network/src/http/Client.hxx
+++ b/network/src/http/Client.hxx
@@ -1,0 +1,227 @@
+#ifndef NETWORK_HTTP_CLIENT_HXX_
+# define NETWORK_HTTP_CLIENT_HXX_
+
+# include <boost/interprocess/sync/lock_options.hpp>
+# include <boost/interprocess/detail/atomic.hpp>
+# include <memory>
+# include <boost/make_shared.hpp>
+# include <boost/iostreams/filtering_stream.hpp>
+# include <boost/iostreams/filter/zlib.hpp>
+# include <boost/iostreams/filter/gzip.hpp>
+# include <boost/iostreams/filter/bzip2.hpp>
+# include <boost/iostreams/filtering_stream.hpp>
+# include <log.hh> // libcore
+# include "http/Connection.hh"
+# include "http/Request.hh"
+# include "http/Response.hh"
+
+
+namespace atom = boost::interprocess::ipcdetail;
+
+namespace xtd {
+namespace network {
+namespace http {
+
+
+template<typename TDomain>
+Client<TDomain>::Client(const utils::Config& p_conf) :
+  TBase(p_conf),
+  m_userSemaphore(0),
+  m_status(cnxstatus::available),
+  m_response()
+{
+}
+
+template<typename TDomain>
+Client<TDomain>::~Client(void)
+{
+}
+
+template<typename TDomain>
+typename Client<TDomain>::cnx_sptr_t
+Client<TDomain>::createCnx(string p_hostname, uint32_t p_port)
+{
+  cnx_sptr_t l_result(new Connection<TDomain>(TBase::m_conf, TBase::m_ioService, p_hostname, p_port));
+  return l_result;
+}
+
+
+template<typename TDomain>
+status
+Client<TDomain>::send(const Request& p_request)
+{
+  utils::vectorBytes_t l_buff;
+  auto&                l_conn = TBase::m_connection;
+
+  atom::atomic_inc32(&(this->m_sendTotal));
+
+  if (m_status != cnxstatus::available)
+  {
+    log::err("network.http.client", "http client send (%s) : can't send multiple request without receive", TBase::m_connection->info(), HERE);
+    atom::atomic_inc32(&(this->m_sendError));
+    return status::error;
+  }
+
+  m_lastSend = boost::posix_time::microsec_clock::local_time();
+  m_status   = cnxstatus::reserved;
+
+  {
+    boost::iostreams::filtering_ostream l_stream;
+    l_stream.push(boost::iostreams::back_inserter(l_buff));
+    p_request.write(l_stream);
+    l_stream.flush();
+  }
+
+  l_conn->send(l_buff,
+               std::bind(&Client::onSent,
+                         this,
+                         std::placeholders::_1));
+
+  atom::atomic_inc32(&(this->m_sendSuccess));
+  return status::ok;
+}
+
+
+
+template<typename TDomain>
+void
+Client<TDomain>::onSent(const boost::system::error_code p_error)
+{
+  log::debug("network.http.client", "http client onSent (%s) : entering", TBase::m_connection->info(), HERE);
+
+  if (p_error == boost::asio::error::operation_aborted)
+  {
+    log::err("network.http.client", "http client onSent (%s) : timeout detected (error '%s')", TBase::m_connection->info(), p_error.message(), HERE);
+    m_status = cnxstatus::timeout;
+    m_userSemaphore.post();
+    return;
+  }
+
+  if (p_error)
+  {
+    log::err("network.http.client", "http client onSent (%s) : send failed with error '%s'", TBase::m_connection->info(), p_error.message(), HERE);
+    m_status = cnxstatus::error;
+    m_userSemaphore.post();
+    return;
+  }
+
+  m_status = cnxstatus::sent;
+  do_receive();
+  log::debug("network.http.client", "http client onSent (%s) : leaving", TBase::m_connection->info(), HERE);
+}
+
+
+
+
+
+
+template<typename TDomain>
+void
+Client<TDomain>::do_receive(void)
+{
+  log::debug("network.http.client", "http client do_receive (%s) : entering", TBase::m_connection->info(), HERE);
+  auto& l_conn = TBase::m_connection;
+
+  utils::sharedBuf_t l_res = std::make_shared<utils::vectorBytes_t>();
+  l_conn->receive(l_res,
+                  std::bind(&Client::onReceived,
+                            this,
+                            std::placeholders::_1,
+                            l_res));
+  log::debug("network.http.client", "http client do_receive (%s) : leaving", TBase::m_connection->info(), HERE);
+}
+
+
+
+template<typename TDomain>
+void
+Client<TDomain>::onReceived(const boost::system::error_code p_error,
+                            utils::sharedBuf_t              p_response)
+{
+  utils::scoped_method l_semPos(std::bind(&boost::interprocess::interprocess_semaphore::post, std::ref(m_userSemaphore)));
+
+  log::debug("network.http.client", "http client onReceived (%s) : entering", TBase::m_connection->info(), HERE);
+
+  if (p_error ==  boost::asio::error::operation_aborted)
+  {
+    log::err("network.http.client", "http client onReceived (%s) : timeout detected (error '%s')", TBase::m_connection->info(), p_error.message(), HERE);
+    m_status = cnxstatus::timeout;
+    return;
+  }
+
+  if (p_error)
+  {
+    log::err("network.http.client", "http client onReceived (%s) : error '%s'", TBase::m_connection->info(), p_error.message(), HERE);
+    m_status = cnxstatus::error;
+    return;
+  }
+
+  if (m_status != cnxstatus::sent)
+  {
+    log::err("network.http.client", "http client onReceived (%s) : request has invalid status '%d'", TBase::m_connection->info(), HERE);
+    m_status = cnxstatus::error;
+    return;
+  }
+
+  m_status = cnxstatus::received;
+  m_response.swap(*p_response);
+
+  boost::posix_time::time_duration l_diff =
+    boost::posix_time::microsec_clock::local_time() - m_lastSend;
+
+  TBase::m_lastRTTMs = l_diff.total_milliseconds();
+  log::debug("network.http.client", "http onReceived (%s) : client received finished", TBase::m_connection->info(), HERE);
+}
+
+template<typename TDomain>
+status
+Client<TDomain>::receive(Response& p_response)
+{
+  log::debug("network.http.client", "http client receive (%s) : entering", TBase::m_connection->info(), HERE);
+  atom::atomic_inc32(&(this->m_receiveTotal));
+
+  if (m_status == cnxstatus::available)
+  {
+    log::err("network.http.client", "http client receive : unsent request", HERE);
+    atom::atomic_inc32(&(this->m_receiveError));
+    return status::error;
+  }
+
+  utils::do_sem_wait(m_userSemaphore);
+
+  if (m_status == cnxstatus::timeout)
+  {
+    log::err("network.http.client", "http client receive : timeout error", HERE);
+    m_status = cnxstatus::available;
+    atom::atomic_inc32(&(this->m_receiveTimeout));
+    return status::timeout;
+  }
+
+  if (m_status != cnxstatus::received)
+  {
+    log::err("network.http.client", "http client receive : receive error (status '%d')", HERE);
+    m_status = cnxstatus::available;
+    atom::atomic_inc32(&(this->m_receiveError));
+    return status::error;
+  }
+
+  m_status = cnxstatus::available;
+
+  boost::iostreams::filtering_istream l_fis;
+  l_fis.push(boost::make_iterator_range(m_response));
+
+  if (status::ok != p_response.read(l_fis))
+  {
+    log::crit("network.http.client", "http client receive (%s) : can't deserialize structure", TBase::m_connection->info(), HERE);
+    atom::atomic_inc32(&(this->m_receiveError));
+    return status::error;
+  }
+
+  log::debug("network.http.client", "http client receive (%s) : leaving", TBase::m_connection->info(), HERE);
+  atom::atomic_inc32(&(this->m_receiveSuccess));
+  return status::ok;
+}
+
+}}} //end namespaces
+
+#endif // !NETWORK_HTTP_CLIENT_HH_

--- a/network/src/http/Connection.hh
+++ b/network/src/http/Connection.hh
@@ -41,10 +41,10 @@ private:
   static const uint32_t mcs_maxReadLength = 128;
 
 public:
-  explicit Connection(const utils::Config& p_configuration,
-                      boost::asio::io_service&                p_ioService,
-                      const string                       p_hostname,
-                      const uint32_t                     p_port);
+  explicit Connection(const utils::Config&     p_configuration,
+                      boost::asio::io_service& p_ioService,
+                      const string             p_hostname,
+                      const uint32_t           p_port);
   virtual ~Connection(void);
 
 private:
@@ -57,27 +57,27 @@ public:
   bool getClosedByServer(void) const;
 
 private:
-  void onSent(const boost::system::error_code           p_error,
-              size_t                               /* p_bytesTransferred */,
-              utils::handler_t                          p_onSent);
+  void onSent(const boost::system::error_code    p_error,
+              size_t                          /* p_bytesTransferred */,
+              utils::handler_t                   p_onSent);
 
-  void onHeaderReceived(const boost::system::error_code           p_error,
+  void onHeaderReceived(const boost::system::error_code         p_error,
                         size_t                               /* p_bytesTransferred */,
-                        utils::sharedBuf_t                        p_inData,
+                        utils::sharedBuf_t                      p_inData,
                         std::shared_ptr<boost::asio::streambuf> p_header,
-                        utils::handler_t                          p_onReceived);
+                        utils::handler_t                        p_onReceived);
 
-  void onDataReceived(const boost::system::error_code           p_error,
+  void onDataReceived(const boost::system::error_code         p_error,
                       size_t                               /* p_bytesTransferred */,
-                      utils::sharedBuf_t                        p_inData,
-                      utils::sharedBuf_t                        p_data,
-                      utils::handler_t                          p_onReceived);
+                      utils::sharedBuf_t                      p_inData,
+                      utils::sharedBuf_t                      p_data,
+                      utils::handler_t                        p_onReceived);
 
-  void receive_data(size_t        p_dataSize,
+  void receive_data(size_t             p_dataSize,
                     utils::sharedBuf_t p_inData,
                     utils::handler_t   p_onReceived);
 
-  void do_receive_data(size_t        p_dataSize,
+  void do_receive_data(size_t             p_dataSize,
                        utils::sharedBuf_t p_inData,
                        utils::handler_t   p_onReceived);
 

--- a/network/src/http/Message.cc
+++ b/network/src/http/Message.cc
@@ -1,0 +1,267 @@
+#include "http/Message.hh"
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/find_format.hpp>
+#include <boost/algorithm/string/regex_find_format.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <log.hh>  // libcore
+
+namespace xtd {
+namespace network {
+namespace http {
+
+
+Message::Message(void):
+  m_version(version::v1_0),
+  m_headers()
+{
+}
+
+Message::~Message(void)
+{
+}
+
+void
+Message::setVersion(version p_version)
+{
+  m_version = p_version;
+}
+
+version
+Message::getVersion(void) const
+{
+  return m_version;
+}
+
+
+bool
+Message::existsHeader(const string& p_name) const
+{
+  return m_headers.count(p_name) != 0;
+}
+
+
+void
+Message::addHeader(const string& p_name,
+                   const string& p_value)
+{
+  m_headers[p_name] = p_value;
+}
+
+
+
+bool
+Message::getHeader(const string& p_name, string& p_value) const
+{
+  t_header_map::const_iterator c_header = m_headers.find(p_name);
+
+  if (c_header == m_headers.end())
+    return false;
+  p_value = c_header->second;
+  return true;
+}
+
+const Message::t_header_map&
+Message::getHeaders(void) const
+{
+  return m_headers;
+}
+
+
+status
+Message::readHeaders(istream& p_request)
+{
+  while (false == p_request.eof())
+  {
+    vector<string> l_parts;
+    string         l_line;
+
+    getline(p_request, l_line);
+    boost::trim_if(l_line, boost::is_any_of("\t\r\n "));
+    if (0 == l_line.size())
+      break;
+
+    l_parts.push_back(l_line.substr(0, l_line.find_first_of(":")));
+    l_parts.push_back(l_line.substr(l_line.find_first_of(":") + 1));
+    boost::trim(l_parts[0]);
+    boost::trim(l_parts[1]);
+    addHeader(l_parts[0], l_parts[1]);
+    log::info("network.http.request", "received header %s: %s", l_parts[0], l_parts[1], HERE);
+  }
+
+  return status::ok;
+}
+
+status
+Message::readVersion(const string& p_version)
+{
+  size_t l_pos = p_version.find_last_of("/");
+
+  if (p_version.substr(0, l_pos) != "HTTP")
+  {
+    log::err("network.http.request", "version error : invalid", HERE);
+    return status::error;
+  }
+
+  string l_version = p_version.substr(l_pos + 1);
+
+  if (l_version == "1.0")
+    setVersion(version::v1_0);
+  else if (l_version == "1.1")
+    setVersion(version::v1_1);
+  else
+  {
+    log::err("network.http.request", "initial line error : unknown version '%s'", l_version, HERE);
+    return status::error;
+  }
+
+  return status::ok;
+}
+
+
+status
+Message::read(std::istream& p_request)
+{
+  if (status::ok != readHead(p_request))
+  {
+    log::err("network.http.request", "protocol error : bad initial line", HERE);
+    return status::error;
+  }
+
+  if (status::ok != readData(p_request))
+  {
+    log::err("network.http.request", "protocol error : invalid data", HERE);
+    return status::error;
+  }
+
+  return status::ok;
+}
+
+
+status
+Message::readHead(std::istream& p_request)
+{
+  if (status::ok != readInitial(p_request))
+  {
+    log::err("network.http.request", "protocol error : bad initial line", HERE);
+    return status::error;
+  }
+
+  if (status::ok != readHeaders(p_request))
+  {
+    log::err("network.http.request", "protocol error : bad headers lines", HERE);
+    return status::error;
+  }
+
+  return status::ok;
+}
+
+
+status
+Message::readInitial(istream& p_request)
+{
+  string         l_line;
+  vector<string> l_parts;
+
+  getline(p_request, l_line);
+  boost::trim_if(l_line, boost::is_any_of(" \n\r\t"));
+  return status::ok;
+}
+
+
+status
+Message::getDataSize(size_t& p_length) const
+{
+  string l_strVal;
+
+  if (false == getHeader("Content-Length", l_strVal))
+  {
+    p_length = 0;
+    return status::ok;
+  }
+
+  try {
+    p_length = boost::lexical_cast<size_t>(l_strVal);
+  }
+  catch (boost::bad_lexical_cast)
+  {
+
+    log::err("network.http.request", "read data : unable to interpret content-length '%s' as int", l_strVal, HERE);
+    return status::error;
+  }
+
+  return status::ok;
+}
+
+
+
+/**
+ ** @details
+ ** on lit jusqu'a eof et on append dans m_data chaque chunk
+ */
+status
+Message::readData(istream& p_request)
+{
+  size_t l_length;
+
+  copy(std::istreambuf_iterator<char>(p_request.rdbuf()),
+       std::istreambuf_iterator<char>(),
+       back_inserter(m_data));
+
+  if (status::error == getDataSize(l_length))
+  {
+    log::err("network.http.request", "read data : error while gettin data length", HERE);
+    return status::error;
+  }
+
+  if (l_length < m_data.size())
+  {
+    log::err("network.http.request", "read data : read more data than expected", HERE);
+    return status::error;
+  }
+
+  return status::ok;
+}
+
+void
+Message::write(std::ostream& p_stream) const
+{
+  writeInitial(p_stream);
+  writeHeaders(p_stream);
+  p_stream << "\r\n";
+  writeData(p_stream);
+}
+
+void
+Message::writeInitial(std::ostream& /* p_stream */) const
+{
+}
+
+void
+Message::writeData(std::ostream& p_stream) const
+{
+  p_stream << getData();
+}
+
+void
+Message::writeHeaders(std::ostream& p_stream) const
+{
+  p_stream << format::vargs("Content-Length: %d\r\n", getData().size());
+  for (auto& c_header : getHeaders())
+    p_stream << format::vargs("%s: %s\r\n", c_header.first, c_header.second);
+}
+
+
+const string&
+Message::getData(void) const
+{
+  return m_data;
+}
+
+
+
+
+}}}

--- a/network/src/http/Message.hh
+++ b/network/src/http/Message.hh
@@ -1,0 +1,53 @@
+#ifndef NETWORK_HTTP_MESSAGE_HH_
+# define NETWORK_HTTP_MESSAGE_HH_
+# include "types.hh" //libhttp
+# include <types.hh> //libcore
+
+namespace xtd {
+namespace network {
+namespace http {
+
+class Message
+{
+public:
+  typedef map<string, string> t_header_map;
+
+public:
+  Message(void);
+  virtual ~Message(void);
+
+public:
+  bool                existsHeader(const string& p_name) const;
+  bool                getHeader(const string& p_name, string& p_value) const;
+  const t_header_map& getHeaders(void) const;
+  void                addHeader(const string& p_name, const string& p_value);
+  void                setVersion(version p_version);
+  version             getVersion(void) const;
+  status              getDataSize(size_t& p_length) const;
+  const string&       getData(void) const;
+
+public:
+  status read(std::istream& p_request);
+  status readHead(std::istream& p_request);
+  void   write(std::ostream& p_stream) const;
+
+protected:
+  virtual status readVersion(const string& p_version);
+  virtual status readHeaders(std::istream& p_stream);
+  virtual status readInitial(std::istream& p_stream);
+  virtual status readData(std::istream& p_stream);
+  virtual void   writeInitial(std::ostream& p_stream) const;
+  virtual void   writeData(std::ostream& p_stream) const;
+  virtual void   writeHeaders(std::ostream& p_stream) const;
+
+
+protected:
+  version      m_version;
+  t_header_map m_headers;
+  string       m_data;
+};
+
+
+}}}
+
+#endif // !NETWORK_HTTP_MESSAGE_HH_

--- a/network/src/http/Request.hh
+++ b/network/src/http/Request.hh
@@ -7,67 +7,41 @@
 # include <boost/regex.hpp>
 # include <boost/noncopyable.hpp>
 # include <types.hh> // libcore
+# include "http/Message.hh"
 
 namespace xtd {
 namespace network {
 namespace http {
 
-class Request
+class Request : public Message
 {
   friend std::ostream& operator<<(std::ostream&, const Request&);
 
 public:
   typedef std::multimap<string, string> t_param_map;
-  typedef map<string, string>      t_header_map;
-
-  enum t_method {
-    METHOD_GET  = 0,
-    METHOD_POST = 1,
-    METHOD_HEAD = 2
-  };
-
-  enum t_version {
-    VERSION_1_0 = 0,
-    VERSION_1_1 = 1
-  };
 
 public:
-  Request(bool p_cgiToLower = true);
+  Request(void);
 
 public:
-  void setMethod(t_method p_method);
+  void setPath(const string& p_path);
+  void setMethod(method p_method);
   void addCgi(const string& p_key, const string& p_value);
   void addPost(const string& p_key, const string& p_value);
-  void addHeader(const string& p_name, const string& p_value);
-  void setVersion(const string& p_version);
-  void setVersion(t_version p_version);
   void removeCgi(const string& p_key);
   void removePost(const string& p_key);
   void removeData(const string& p_key);
 
-  status   readQS(const string& p_qs);
-  status   readHead(std::istream& p_request);
-  status   read(std::istream& p_request);
-
-
-  t_method            getMethod(void) const;
-  const string&  getPath(void) const;
-  string         getQS(void) const;
-  string         getRawUrl(void) const;
-  const t_param_map&  getCgis(void) const;
-  const t_param_map&  getPosts(void) const;
-  t_param_map         getParams(void) const;
-  bool                existsCgi(const string& p_key) const;
-  bool                existsPost(const string& p_key) const;
-  bool                existsParam(const string& p_key) const;
-  bool                existsHeader(const string& p_name) const;
-  bool                getHeader(const string& p_name, string& p_value) const;
-  const t_header_map& getHeaders(void) const;
-  const string&  getVersionStr(void) const;
-  t_version           getVersion(void) const;
-  status    getDataSize(size_t& p_length) const;
-
-
+  method             getMethod(void) const;
+  const string&      getPath(void) const;
+  string             getQS(void) const;
+  string             getRawUrl(void) const;
+  const t_param_map& getCgis(void) const;
+  const t_param_map& getPosts(void) const;
+  t_param_map        getParams(void) const;
+  bool               existsCgi(const string& p_key) const;
+  bool               existsPost(const string& p_key) const;
+  bool               existsParam(const string& p_key) const;
 
   template<typename T>
   bool getCgi(const string& p_key, T& p_dst) const;
@@ -90,17 +64,14 @@ public:
   template<typename T>
   void getParam(const string& p_key, vector<T>& p_dst, const vector<T>& p_default) const;
 
-
 private:
-  status readData(std::istream& p_request);
-  status readDataFormEncoded(const string& p_data);
-  status readHeaders(std::istream& p_request);
-  status readVersion(const string& p_version);
+  status readInitial(std::istream& p_request) override;
   status readUrl(const string&  p_url);
   status readMethod(const string& p_method);
-  status readInitial(std::istream& p_request);
-  string paramValueDecode(const string& p_value);
-  void        normalizePath(const string& p_path);
+  status readData(std::istream& p_request) override;
+  status readDataFormEncoded(const string& p_data);
+  void   writeInitial(std::ostream& p_stream) const override;
+  void   normalizePath(const string& p_path);
 
   bool as(const string& p_src, string& p_dst) const;
   bool as(const string& p_src, bool&        p_dst) const;
@@ -119,15 +90,11 @@ private:
   void getData(const t_param_map& p_src, const string& p_key, vector<T>& p_dst, const vector<T>& p_default) const;
 
 private:
-  string  m_rawUrl;
-  t_method     m_method;
-  string  m_path;
+  string       m_rawUrl;
+  method       m_method;
+  string       m_path;
   t_param_map  m_cgi;
   t_param_map  m_post;
-  t_header_map m_headers;
-  string  m_versionStr;
-  t_version    m_version;
-  bool         m_cgiToLower;
   boost::regex m_regex_tooManyStartingSlash;
   boost::regex m_regex_tooManyEndingSlash;
 };

--- a/network/src/http/Response.cc
+++ b/network/src/http/Response.cc
@@ -2,7 +2,7 @@
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/format.hpp>
+#include <format.hh> // libcore
 
 
 
@@ -14,8 +14,6 @@ namespace http {
 
 Response::Response(void) :
   m_status(code::bad_request),
-  m_headers(),
-  m_data(),
   m_cachable(false)
 {
 }
@@ -33,12 +31,6 @@ Response::setStatus(code p_status)
 }
 
 void
-Response::addHeader(const string& p_name, const string& p_value)
-{
-  m_headers[p_name] = p_value;
-}
-
-void
 Response::setData(const string& p_data)
 {
   m_data = p_data;
@@ -51,52 +43,17 @@ Response::appendData(const string& p_data)
   m_data += p_data;
 }
 
-void
-Response::setVersion(const string& p_version)
-{
-  m_version = p_version;
-}
-
 code
 Response::getStatus(void) const
 {
   return m_status;
 }
 
-bool
-Response::getHeader(const string& p_name, string& p_value) const
-{
-  t_header_map::const_iterator c_header = m_headers.find(p_name);
-  if (c_header == m_headers.end())
-    return false;
-  p_value = c_header->second;
-  return true;
-}
-
-const Response::t_header_map&
-Response::getHeaders(void) const
-{
-  return m_headers;
-}
-
-const string&
-Response::getData(void) const
-{
-  return m_data;
-}
-
-const string&
-Response::getVersion(void) const
-{
-  return m_version;
-}
-
 
 void
-Response::finalize(void)
+Response::writeHeaders(std::ostream& p_stream) const
 {
-  addHeader("Content-Size",   boost::lexical_cast<string>(getData().size()));
-  addHeader("Content-Length", boost::lexical_cast<string>(getData().size()));
+  Message::writeHeaders(p_stream);
 
   if (true == m_cachable)
   {
@@ -105,74 +62,35 @@ Response::finalize(void)
     boost::posix_time::ptime l_time        =
       boost::posix_time::second_clock::universal_time() +
       boost::posix_time::seconds(l_cacheTTLSec);
-
     l_out.imbue(std::locale(l_out.getloc(), new boost::posix_time::time_facet("%a, %d %b %Y %H:%M:%S GMT")));
     l_out << l_time;
-
-    addHeader("Expires",       l_out.str());
-    addHeader("Cache-Control", boost::str(boost::format("private,maxage=%d") % l_cacheTTLSec));
+    p_stream << format::vargs("Expires: %d\r\n", l_out.str());
+    p_stream << format::vargs("Cache-Control: private,maxage=%d\r\n", l_cacheTTLSec);
   }
   else
   {
-    addHeader("Pragma",        "no-cache");
-    addHeader("Cache-Control", "no-cache");
+    p_stream << "Pragma: no-cache\r\n";
+    p_stream << "Cache-Control: no-cache\r\n";
   }
 }
-
 
 void
-Response::write(std::ostream& p_response) const
+Response::writeInitial(std::ostream& p_stream) const
 {
-  t_header_map::const_iterator c_header;
-  string                       l_status = statusToMessage(getStatus());
-  string                       l_data   = getData();
-
-  p_response << boost::format("HTTP/%s %s\r\n") % getVersion() % l_status;
-  for (c_header = getHeaders().begin();
-       c_header != getHeaders().end();
-       c_header++)
-    p_response << boost::str(boost::format("%s: %s\r\n")
-                             % c_header->first
-                             % c_header->second);
-  p_response << "\r\n";
-  p_response << getData();
+  string l_status = str(getStatus());
+  p_stream << format::vargs("HTTP/%s %s\r\n", str(getVersion()) , l_status);
 }
 
-string
-Response::statusToMessage(code p_status)
+
+
+ostream& operator<<(ostream& p_buf, const Response& p_obj)
 {
-  string l_value;
-
-  switch (p_status)
-  {
-    //Information 1xx
-  case code::proceeed:            l_value = "100 Continue";              break;
-  case code::switch_protocol:     l_value = "101 Switching protocol";    break;
-    //Successful 2xx
-  case code::ok:                  l_value = "200 OK";                    break;
-  case code::created:             l_value = "201 Created";               break;
-  case code::accepted:            l_value = "202 Accepted";              break;
-  case code::no_content:          l_value = "204 No Content";            break;
-  case code::partial_content:     l_value = "206 Partial content";       break;
-
-    //Redirection 3xx
-  case code::multiple_choices:    l_value = "300 Multiple Choices";      break;
-  case code::moved_permanently:   l_value = "301 Moved Permanently";     break;
-  case code::moved_temporarily:   l_value = "302 Moved Temporarily";     break;
-  case code::not_modified:        l_value = "304 Not Modified";          break;
-    //Client Error 4xx
-  case code::bad_request:         l_value = "400 Bad Request";           break;
-  case code::unauthorized:        l_value = "401 Unauthorized";          break;
-  case code::forbidden:           l_value = "403 Forbidden";             break;
-  case code::not_found:           l_value = "404 Not Found";             break;
-  case code::method_not_allowed:  l_value = "405 Method not allowed";    break;
-    //Server Error 5xx
-  case code::internal_error:      l_value = "500 Internal Server Error"; break;
-  case code::not_implemented:     l_value = "501 Not Implemented";       break;
-  case code::bad_gateway:         l_value = "502 Bad Gateway";           break;
-  case code::service_unavailable: l_value = "503 Service Unavailable";   break;
-  }
-  return l_value;
+  p_buf << "code : "    << str(p_obj.getStatus())  << endl;
+  p_buf << "version : " << str(p_obj.getVersion()) << endl;
+  p_buf << "headers :"  << endl;
+  for (auto& cc_header : p_obj.getHeaders())
+    p_buf << " -> " << cc_header.first << ": " << cc_header.second << endl;
+  return p_buf;
 }
 
 }}} //end namespaces

--- a/network/src/http/Response.hh
+++ b/network/src/http/Response.hh
@@ -1,75 +1,35 @@
 #ifndef NETWORK_HTTP_RESPONSE_HH_
 # define NETWORK_HTTP_RESPONSE_HH_
 
-#include <types.hh> //libcore
+# include <types.hh> //libcore
+# include "http/Message.hh"
 
 namespace xtd {
 namespace network {
 namespace http {
 
-enum class code : uint32_t {
-  //Information 1xx
-  proceeed, //Continue
-  switch_protocol, //Switching protocol
-  //Successful 2xx
-  ok, //OK
-  created, //Created
-  accepted, //Accepted
-  no_content, //No Content
-  partial_content, //Partial content
-  //Redirection 3xx
-  multiple_choices, //Multiple Choices
-  moved_permanently, //Moved Permanently
-  moved_temporarily, //Moved Temporarily
-  not_modified, //Not Modified
-  //Client Error 4xx
-  bad_request, //Bad Request
-  unauthorized, //Unauthorized
-  forbidden, //Forbidden
-  not_found, //Not Found
-  method_not_allowed, //Method not allowed
-  //Server Error 5xx
-  internal_error, //Internal Server Error
-  not_implemented, //Not Implemented
-  bad_gateway, //Bad Gateway
-  service_unavailable //Service Unavailable
- };
-
-class Response
+class Response : public Message
 {
-public:
-  typedef map<string, string> t_header_map;
-
 public:
   Response(void);
 
 public:
   void setStatus(code p_status);
-  void addHeader(const string& p_name, const string& p_value);
   void setData(const string& p_data);
   void appendData(const string& p_data);
-  void setVersion(const string& p_version);
   void setCachable(bool p_status);
-
-  code          getStatus(void) const;
-  bool                getHeader(const string& p_name, string& p_value) const;
-  const t_header_map& getHeaders(void) const;
-  const string&       getData(void) const;
-  const string&       getVersion(void) const;
-  static string       statusToMessage(code p_status);
-
+  code getStatus(void) const;
 
 public:
-  void write(std::ostream& p_response) const;
-  void finalize(void);
+  void writeInitial(std::ostream& p_stream) const override;
+  void writeHeaders(std::ostream& p_stream) const override;
 
 private:
-  string       m_version;
   code         m_status;
-  t_header_map m_headers;
-  string       m_data;
   bool         m_cachable;
 };
+
+std::ostream& operator<<(std::ostream& p_buf, const Response& p_obj);
 
 
 }}} //end namespaces

--- a/network/src/http/Server.cc
+++ b/network/src/http/Server.cc
@@ -4,8 +4,26 @@
 
 namespace xtd {
 namespace network {
-
 namespace http {
+
+std::function<bool(const Request& p_req)>
+operator&&(std::function<bool(const Request& p_req)> p_fn1,
+           std::function<bool(const Request& p_req)> p_fn2)
+{
+  return [&p_fn1,&p_fn2](const Request& p_req) -> bool {
+    return p_fn1(p_req) && p_fn2(p_req);
+  };
+}
+
+
+std::function<bool(const Request& p_req)>
+operator||(std::function<bool(const Request& p_req)> p_fn1,
+           std::function<bool(const Request& p_req)> p_fn2)
+{
+  return [&p_fn1,&p_fn2](const Request& p_req) -> bool {
+    return p_fn1(p_req) || p_fn2(p_req);
+  };
+}
 
 template class Server<utils::af_unix>;
 template class Server<utils::af_inet>;

--- a/network/src/http/Template.cc
+++ b/network/src/http/Template.cc
@@ -3,17 +3,11 @@
 #include <fstream>
 #include <iterator>
 #include <boost/assign/std/vector.hpp>
-#include <boost/range/algorithm/for_each.hpp>
-#include <boost/lambda/lambda.hpp>
-#include <boost/lambda/bind.hpp>
-#include <boost/format.hpp>
 #include <json_parser.hpp> // libcore
 #include <text.hh>         // libcore
 #include <log.hh>          // libcore
 
-using namespace boost::assign;
-using namespace boost;
-
+using boost::assign::operator+=;
 
 namespace xtd {
 namespace network {

--- a/network/src/http/Template.hxx
+++ b/network/src/http/Template.hxx
@@ -2,9 +2,9 @@
 # define NETWORK_HTTP_TEMPLATE_HXX_
 
 # include <boost/algorithm/string/replace.hpp>
-# include <boost/format.hpp>
 # include <json_parser.hpp> // libcore
 # include <log.hh>          // libcore
+# include <format.hh>       // libcore
 
 namespace xtd {
 namespace network {
@@ -49,7 +49,7 @@ Json::add(const string& p_path,
   try {
     m_root.put<T>(l_path, p_val, json_parser::translator<T>());
   } catch (const ptree_bad_data& l_error) {
-    addError(boost::str(boost::format("json add value error : %s") % l_error.what()));
+    addError(format::vargs("json add value error : %s", l_error.what()));
   }
 }
 

--- a/network/src/http/cpptempl.cc
+++ b/network/src/http/cpptempl.cc
@@ -1,6 +1,6 @@
 #include "cpptempl.hh"
-#include <boost/format.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <format.hh> // libcore
 
 namespace xtd {
 namespace network {
@@ -67,12 +67,12 @@ data_ptr parse_val(string key, data_map &data)
   if (index == string::npos)
   {
     if (data.end() == (cc_value = data.find(key)))
-      throw TemplateException(boost::str(boost::format("unresolved key : %s") % key));
+      throw TemplateException(format::vargs("unresolved key : %s", key));
     return cc_value->second;
   }
 
   if (data.end() == (cc_value = data.find(key.substr(0, index))))
-    throw TemplateException(boost::str(boost::format("unresolved key : %s") % key.substr(0, index)));
+    throw TemplateException(format::vargs("unresolved key : %s", key.substr(0, index)));
 
   data_ptr item = cc_value->second;
   return parse_val(key.substr(index+1), item->getmap());

--- a/network/src/http/types.cc
+++ b/network/src/http/types.cc
@@ -1,0 +1,72 @@
+#include "types.hh"
+
+namespace xtd {
+namespace network {
+namespace http {
+
+string str(version p_version)
+{
+  switch (p_version)
+  {
+  case version::v1_0:
+    return "1.0";
+  case version::v1_1:
+    return "1.1";
+  };
+  return "";
+}
+
+string str(method  p_method)
+{
+  string l_value;
+
+  switch (p_method)
+  {
+  case method::get:    l_value = "GET";    break;
+  case method::post:   l_value = "POST";   break;
+  case method::head:   l_value = "HEAD";   break;
+  case method::patch:  l_value = "PATCH";  break;
+  case method::put:    l_value = "PUT";    break;
+  case method::del:    l_value = "DELETE"; break;
+  }
+  return l_value;
+}
+
+string str(code p_status)
+{
+  string l_value;
+
+  switch (p_status)
+  {
+    //Information 1xx
+  case code::proceeed:            l_value = "100 Continue";              break;
+  case code::switch_protocol:     l_value = "101 Switching protocol";    break;
+    //Successful 2xx
+  case code::ok:                  l_value = "200 OK";                    break;
+  case code::created:             l_value = "201 Created";               break;
+  case code::accepted:            l_value = "202 Accepted";              break;
+  case code::no_content:          l_value = "204 No Content";            break;
+  case code::partial_content:     l_value = "206 Partial content";       break;
+
+    //Redirection 3xx
+  case code::multiple_choices:    l_value = "300 Multiple Choices";      break;
+  case code::moved_permanently:   l_value = "301 Moved Permanently";     break;
+  case code::moved_temporarily:   l_value = "302 Moved Temporarily";     break;
+  case code::not_modified:        l_value = "304 Not Modified";          break;
+    //Client Error 4xx
+  case code::bad_request:         l_value = "400 Bad Request";           break;
+  case code::unauthorized:        l_value = "401 Unauthorized";          break;
+  case code::forbidden:           l_value = "403 Forbidden";             break;
+  case code::not_found:           l_value = "404 Not Found";             break;
+  case code::method_not_allowed:  l_value = "405 Method not allowed";    break;
+    //Server Error 5xx
+  case code::internal_error:      l_value = "500 Internal Server Error"; break;
+  case code::not_implemented:     l_value = "501 Not Implemented";       break;
+  case code::bad_gateway:         l_value = "502 Bad Gateway";           break;
+  case code::service_unavailable: l_value = "503 Service Unavailable";   break;
+  }
+  return l_value;
+}
+
+
+}}}

--- a/network/src/http/types.hh
+++ b/network/src/http/types.hh
@@ -1,0 +1,57 @@
+#ifndef NETWORK_HTTP_TYPES_HH_
+# define NETWORK_HTTP_TYPES_HH_
+# include <types.hh> //libcore
+
+namespace xtd {
+namespace network {
+namespace http {
+
+enum class version : uint32_t {
+  v1_0,
+  v1_1
+ };
+
+enum class method : uint32_t {
+  get    = 0,
+  post   = 1,
+  head   = 2,
+  patch  = 3,
+  put    = 4,
+  del    = 5
+ };
+
+enum class code : uint32_t {
+  //Information 1xx
+  proceeed, //Continue
+  switch_protocol, //Switching protocol
+  //Successful 2xx
+  ok, //OK
+  created, //Created
+  accepted, //Accepted
+  no_content, //No Content
+  partial_content, //Partial content
+  //Redirection 3xx
+  multiple_choices, //Multiple Choices
+  moved_permanently, //Moved Permanently
+  moved_temporarily, //Moved Temporarily
+  not_modified, //Not Modified
+  //Client Error 4xx
+  bad_request, //Bad Request
+  unauthorized, //Unauthorized
+  forbidden, //Forbidden
+  not_found, //Not Found
+  method_not_allowed, //Method not allowed
+  //Server Error 5xx
+  internal_error, //Internal Server Error
+  not_implemented, //Not Implemented
+  bad_gateway, //Bad Gateway
+  service_unavailable //Service Unavailable
+ };
+
+string str(version p_version);
+string str(method  p_method);
+string str(code    p_code);
+
+}}}
+
+#endif // !NETWORK_HTTP_TYPES_HH_

--- a/network/src/utils/CacheDns.cc
+++ b/network/src/utils/CacheDns.cc
@@ -1,4 +1,5 @@
 #include "utils/CacheDns.hh"
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 
 namespace xtd {
@@ -79,7 +80,7 @@ CacheDns::pushElem(const string& p_url,
 void
 CacheDns::createTimeStamp(std::time_t& p_timeStamp)
 {
-  const boost::posix_time::ptime l_time(boost::posix_time::second_clock::universal_time());
+  const bpt::ptime l_time(bpt::second_clock::universal_time());
   p_timeStamp = ptime_to_time_t(l_time);
 }
 

--- a/network/src/utils/CacheDns.hh
+++ b/network/src/utils/CacheDns.hh
@@ -6,19 +6,12 @@
 # include <map>
 # include <utility>
 # include <list>
-
-# include <boost/thread/thread.hpp>
-# include <boost/function.hpp>
 # include <memory>
-# include <boost/noncopyable.hpp>
-# include <boost/bind.hpp>
+
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wsequence-point"
 # include <boost/unordered_map.hpp>
 # pragma GCC diagnostic pop
-# include <boost/make_shared.hpp>
-# include <boost/date_time/posix_time/posix_time.hpp>
-
 # include "utils/CommTypeDefs.hh"
 # include "utils/Utils.hh"
 
@@ -27,17 +20,17 @@ namespace network {
 namespace utils {
 
 const uint32_t CACHE_CAPACITY_MAX = 200;
-const uint32_t CACHE_TTL_MAX = 1800; // 30 minutes
+const uint32_t CACHE_TTL_MAX      = 1800; // 30 minutes
 
 struct CacheEntry
 {
   explicit CacheEntry(const string& p_ipAddress,
-                      uint32_t       p_timeStamp) :
+                      uint32_t      p_timeStamp) :
     m_value(p_ipAddress),
     m_stamp(p_timeStamp)
   {
   }
-  string m_value; //IP address
+  string      m_value; //IP address
   std::time_t m_stamp; //time stamp
 };
 
@@ -56,18 +49,23 @@ typedef boost::unordered_map< string, CacheList::iterator > CacheMap;
  ** Cet objet sert de cache local aux entrees resolues par le Resolver
  ** Rien de compliqué, une paire de <data, timestamp> et un paramètre de TTL
  */
-class CacheDns : boost::noncopyable
+class CacheDns
 {
 public:
   /**
    ** @brief Cache DNS Constructor specifying capacity and entry timetolive
-   ** @param p_capacity : max number of entries in the cache
-   ** @param p_ttl : maximum time to live of an entry in the cache in seconds
+   ** @param p_capacity max number of entries in the cache
+   ** @param p_ttl maximum time to live of an entry in the cache in seconds
    */
   explicit CacheDns(uint32_t p_capacity, uint32_t p_ttl);
 
   /**
-   * \brief pop the element from the pool
+   ** @brief Non copyable object
+   */
+  CacheDns(const CacheDns&) = delete;
+
+  /**
+   * @brief pop the element from the pool
    * @param p_url url of the web site for each we want to retrieve the ip address
    * @param[out] p_ipAddr ip address corresponding to the url
    * @return true if url found in cache and ip address is retrieved
@@ -75,7 +73,7 @@ public:
   bool popElem(const string& p_url, string& p_ipAddr);
 
   /**
-   * \brief push the element in the pool
+   * @brief push the element in the pool
    * @param p_url url of the web site for each we want to add the corresponding the ip address
    * @param p_ipAddr ip address corresponding to the url that we want to add
    */
@@ -95,7 +93,7 @@ private:
   void createTimeStamp(std::time_t& p_time);
 
   /**
-   * \brief checks if timestamp is good and updates if necessary
+   * @brief checks if timestamp is good and updates if necessary
    * @param[out] p_stamp timestamp checked/updated
    * @param[out] p_dnsTimeoutSeconds durée de vite de l'entrée
    * @return true if timestamp is valid and updated
@@ -103,13 +101,13 @@ private:
   bool checkUpdateStamp(std::time_t& p_stamp, uint32_t p_dnsTimeoutSeconds);
 
   /**
-   * \brief moves element to the front of the cache (most recent)
+   * @brief moves element to the front of the cache (most recent)
    * @param p_elem cache entry to move to the front of the cache
    */
   void moveElementFrontLst(const std::shared_ptr<EntryPair> p_elem);
 
   /**
-   * \brief checks if the cache is full(maximum capacity reached) and evicts the oldest element from the cache
+   * @brief checks if the cache is full(maximum capacity reached) and evicts the oldest element from the cache
    */
   void checkAndResize(void);
 

--- a/network/src/utils/CommTypeDefs.hh
+++ b/network/src/utils/CommTypeDefs.hh
@@ -12,25 +12,25 @@ namespace xtd {
 namespace network {
 namespace utils {
 
-typedef boost::asio::deadline_timer                      deadLineTimer_t;
+typedef boost::asio::deadline_timer                    deadLineTimer_t;
 typedef std::shared_ptr<boost::asio::io_service>       ioServicePtr_t;
 typedef std::shared_ptr<boost::asio::io_service::work> workPtr_t;
 typedef std::shared_ptr<boost::asio::streambuf>        streambufPtr_t;
-typedef map<boost::thread::id, size_t>                   t_IdNumberMap;
-typedef std::pair<boost::thread::id, size_t>             t_IdNumberPair;
+typedef map<boost::thread::id, size_t>                 t_IdNumberMap;
+typedef std::pair<boost::thread::id, size_t>           t_IdNumberPair;
 
 // definition of socket type
 typedef boost::asio::local::stream_protocol af_unix;
 typedef boost::asio::ip::tcp                af_inet;
-typedef uint32_t                       requestId_t;
+typedef uint32_t                            requestId_t;
 
 // containers definition
-typedef vector<char>                 vectorBytes_t;
-typedef vector<uint32_t>        vectorUint32_t;
-typedef std::deque<requestId_t>           dequeId_t;
+typedef vector<char>                    vectorBytes_t;
+typedef vector<uint32_t>                vectorUint32_t;
+typedef std::deque<requestId_t>         dequeId_t;
 typedef std::shared_ptr<vectorBytes_t>  sharedBuf_t;
 typedef std::shared_ptr<vectorUint32_t> sharedHeader_t;
-typedef boost::function<void(const boost::system::error_code)> handler_t;
+typedef std::function<void(const boost::system::error_code)> handler_t;
 
 }}} // end namespaces
 

--- a/network/src/utils/Resolver.cc
+++ b/network/src/utils/Resolver.cc
@@ -6,10 +6,7 @@ namespace xtd {
 namespace network {
 namespace utils {
 
-/**
- * @param p_ioService : boost::asio::io_service
- * @param p_ttl : cache entry time to live in seconds
- */
+
 Resolver<af_inet>::Resolver(boost::asio::io_service& p_ioService,uint32_t p_ttl) :
   m_ioService(p_ioService)
 {

--- a/network/src/utils/Resolver.hh
+++ b/network/src/utils/Resolver.hh
@@ -80,7 +80,7 @@ public:
 
 private:
   boost::asio::io_service& m_ioService;
-  uint32_t             m_port;
+  uint32_t                 m_port;
 };
 
 }}} // end namespaces

--- a/network/src/utils/Utils.hh
+++ b/network/src/utils/Utils.hh
@@ -5,13 +5,11 @@
 # include <deque>
 # include <streambuf>
 # include <string>
-# include <boost/date_time/posix_time/posix_time.hpp>
-# include <boost/thread/mutex.hpp>
-# include <boost/enable_shared_from_this.hpp>
-# include <boost/interprocess/sync/interprocess_semaphore.hpp>
-# include <boost/function.hpp>
-# include <boost/noncopyable.hpp>
+# include <mutex>
+# include <functional>
 # include <ctime>
+# include <boost/date_time/posix_time/posix_time.hpp>
+# include <boost/interprocess/sync/interprocess_semaphore.hpp>
 # include "utils/CommTypeDefs.hh"
 
 namespace xtd {
@@ -23,13 +21,14 @@ namespace utils {
 void do_sem_wait(boost::interprocess::interprocess_semaphore& p_sem);
 
 
-class scoped_method : boost::noncopyable
+class scoped_method
 {
 private:
-  typedef boost::function<void(void)> handler_t;
+  typedef std::function<void(void)> handler_t;
 
 public:
   explicit scoped_method(handler_t p_handler) : m_handler(p_handler) { }
+  scoped_method(const scoped_method&) = delete;
   ~scoped_method(void) { m_handler(); }
 
 private:
@@ -40,14 +39,14 @@ template<typename T>
 class deque_id
 {
 public:
-  void        push(const T& p_param);
-  void        push_back(const T& p_param);
-  bool        pop(T& p_param);
-  bool        find(const T& p_param);
+  void   push(const T& p_param);
+  void   push_back(const T& p_param);
+  bool   pop(T& p_param);
+  bool   find(const T& p_param);
   size_t size(void);
 
 private:
-  boost::mutex m_mutex;
+  std::mutex    m_mutex;
   std::deque<T> m_deque;
 };
 

--- a/network/src/utils/Utils.hxx
+++ b/network/src/utils/Utils.hxx
@@ -10,7 +10,7 @@ template<typename T>
 void
 deque_id<T>::push(const T& p_param)
 {
-  boost::mutex::scoped_lock l_lock(m_mutex);
+  std::lock_guard<std::mutex> l_lock(m_mutex);
 
   if (m_deque.end() != std::find(m_deque.begin(), m_deque.end(), p_param))
   {
@@ -25,7 +25,7 @@ template<typename T>
 void
 deque_id<T>::push_back(const T& p_param)
 {
-  boost::mutex::scoped_lock l_lock(m_mutex);
+  std::lock_guard<std::mutex> l_lock(m_mutex);
   m_deque.push_back(p_param);
 }
 
@@ -33,7 +33,7 @@ template<typename T>
 bool
 deque_id<T>::pop(T& p_param)
 {
-  boost::mutex::scoped_lock l_lock(m_mutex);
+  std::lock_guard<std::mutex> l_lock(m_mutex);
   if (m_deque.size() == 0)
     return false;
 
@@ -47,7 +47,7 @@ template<typename T>
 bool
 deque_id<T>::find(const T& p_param)
 {
-  boost::mutex::scoped_lock l_lock(m_mutex);
+  std::lock_guard<std::mutex> l_lock(m_mutex);
   typename std::deque<T>::const_iterator l_it = m_deque.begin();
   for (; l_it !=  m_deque.end(); l_it++)
   {
@@ -61,7 +61,7 @@ template<typename T>
 size_t
 deque_id<T>::size(void)
 {
-  boost::mutex::scoped_lock l_lock(m_mutex);
+  std::lock_guard<std::mutex> l_lock(m_mutex);
   return m_deque.size();
 }
 

--- a/network/unit/TestHttpServer.cc
+++ b/network/unit/TestHttpServer.cc
@@ -8,7 +8,7 @@
 #include <http/Request.hh>
 #include <http/Response.hh>
 #include <http/Client.hh>
-
+#include <base/ClientThreadManager.hh>
 using namespace xtd::network::http;
 
 

--- a/network/unit/TestHttpServer.cc
+++ b/network/unit/TestHttpServer.cc
@@ -172,7 +172,7 @@ TestHttpServer::expiredConnection(void)
   l_req.setVersion(version::v1_0);
 
   // simple 1.0 request, no server keep alive
-  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.connect("localhost", m_port));
+  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.connect("127.0.0.1", m_port));
   CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.send(l_req));
   CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.receive(l_res));
   CPPUNIT_ASSERT_EQUAL(false,           l_res.getHeader("Keep-Alive", l_value));
@@ -180,7 +180,7 @@ TestHttpServer::expiredConnection(void)
 
   l_res = Response();
   l_req.setVersion(version::v1_1);
-  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.connect("localhost", m_port));
+  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.connect("127.0.0.1", m_port));
   CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.send(l_req));
   CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.receive(l_res));
   // this time server let the cnx open

--- a/network/unit/TestHttpServer.cc
+++ b/network/unit/TestHttpServer.cc
@@ -55,6 +55,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestHttpServer);
 void
 TestHttpServer::setUp(void)
 {
+  xtd::network::base::ThreadManager::get();
   m_server.reset(new TestServer());
   m_server->initialize("127.0.0.1", 0, xtd::network::utils::Config(), 10);
   m_server->start();
@@ -66,6 +67,7 @@ TestHttpServer::tearDown(void)
 {
   m_server->stop();
   m_server->join();
+  xtd::network::base::ThreadManager::destroy();
 }
 
 void
@@ -195,7 +197,7 @@ TestHttpServer::expiredConnection(void)
 
   l_res = Response();
   // delay is expired, server should have closed the cnx
-  boost::this_thread::sleep(boost::posix_time::milliseconds(2000));
+  boost::this_thread::sleep(boost::posix_time::milliseconds(3000));
   CPPUNIT_ASSERT_EQUAL(xtd::status::ok,    l_client.send(l_req));
   CPPUNIT_ASSERT_EQUAL(xtd::status::error, l_client.receive(l_res));
 }

--- a/network/unit/TestHttpServer.cc
+++ b/network/unit/TestHttpServer.cc
@@ -1,0 +1,208 @@
+#include <MainTestApplication.hh> // libtests
+#include <TestFixture.hh>         // libtests
+#include <http/Server.hh>         // libnetwork
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/thread/thread.hpp>
+#include <cstdlib>
+#include <sys/wait.h>
+#include <http/Request.hh>
+#include <http/Response.hh>
+#include <http/Client.hh>
+
+using namespace xtd::network::http;
+
+
+class TestHttpServer;
+
+class TestServer : public Server<xtd::network::utils::af_inet>
+{
+  friend class TestHttpServer;
+public:
+  virtual ~TestServer(void) {}
+};
+
+class TestHttpServer : public xtd::tests::TestFixture
+{
+  CPPUNIT_TEST_SUITE(TestHttpServer);
+  CPPUNIT_TEST(unhandledRequest);
+  CPPUNIT_TEST(malformedRequest);
+  CPPUNIT_TEST(simpleHandler);
+  CPPUNIT_TEST(filteredHandler);
+  CPPUNIT_TEST(anyHandler);
+  CPPUNIT_TEST(expiredConnection);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp(void);
+  void tearDown(void);
+
+private:
+  void unhandledRequest(void);
+  void malformedRequest(void);
+  void simpleHandler(void);
+  void filteredHandler(void);
+  void anyHandler(void);
+  void expiredConnection(void);
+
+private:
+  sptr<TestServer> m_server;
+  size_t           m_port;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestHttpServer);
+
+
+void
+TestHttpServer::setUp(void)
+{
+  m_server.reset(new TestServer());
+  m_server->initialize("127.0.0.1", 0, xtd::network::utils::Config(), 10);
+  m_server->start();
+  m_port = m_server->getEndPoint().port();
+}
+
+void
+TestHttpServer::tearDown(void)
+{
+  m_server->stop();
+  m_server->join();
+}
+
+void
+TestHttpServer::unhandledRequest(void)
+{
+  string l_cmd    = xtd::format::vargs("wget -q -O/dev/null http://localhost:%d >/dev/null 2>&1", m_port);
+  exec(l_cmd, 8, __FILE__, __LINE__);
+}
+
+void
+TestHttpServer::malformedRequest(void)
+{
+  string l_cmd = xtd::format::vargs("echo 'GET / HTTP/1.0\r\nContent-Length:1\r\nContent-type:test\r\n\r\na' | nc localhost %d >/dev/null", m_port);
+  exec(l_cmd, 0, __FILE__, __LINE__);
+}
+
+
+void
+TestHttpServer::simpleHandler(void)
+{
+  TestServer::handler l_handler = [](uint32_t, const Request&, Response& p_res)  {
+    p_res.setStatus(code::ok);
+    return xtd::status::ok;
+  };
+
+  m_server->bind("/test", l_handler);
+  string l_cmd = xtd::format::vargs("wget -q -O/dev/null http://localhost:%d/test", m_port);
+  exec(l_cmd, 0, __FILE__, __LINE__);
+}
+
+
+void
+TestHttpServer::filteredHandler(void)
+{
+  TestServer::handler l_200 = [](uint32_t, const Request&, Response& p_res)  {
+    p_res.setStatus(code::ok);
+    return xtd::status::ok;
+  };
+  TestServer::handler l_404 = [](uint32_t, const Request&, Response& p_res)  {
+    p_res.setStatus(code::not_found);
+    return xtd::status::ok;
+  };
+
+  m_server->bind("/test", l_200, [](const Request& p_req) {
+      string l_val;
+      return (true == p_req.getCgi("200", l_val));
+    });
+  m_server->bind("/test", l_404);
+
+  string l_cmd = xtd::format::vargs("wget -q -O/dev/null http://localhost:%d/test?200=1", m_port);
+  exec(l_cmd, 0, __FILE__, __LINE__);
+  l_cmd = xtd::format::vargs("wget -q -O/dev/null http://localhost:%d/test", m_port);
+  exec(l_cmd, 8, __FILE__, __LINE__);
+}
+
+void
+TestHttpServer::anyHandler(void)
+{
+  TestServer::handler l_200 = [](uint32_t, const Request&, Response& p_res)  {
+    p_res.setStatus(code::ok);
+    return xtd::status::ok;
+  };
+  TestServer::handler l_404 = [](uint32_t, const Request&, Response& p_res)  {
+    p_res.setStatus(code::not_found);
+    return xtd::status::ok;
+  };
+
+  m_server->bind_any(l_200);
+  m_server->bind("/test", l_404);
+
+  {
+    string l_cmd = xtd::format::vargs("wget -q -O/dev/null http://localhost:%d/", m_port);
+    exec(l_cmd, 0, __FILE__, __LINE__);
+  }
+
+  {
+    string l_cmd = xtd::format::vargs("wget -q -O/dev/null http://localhost:%d/foo", m_port);
+    exec(l_cmd, 0, __FILE__, __LINE__);
+  }
+
+  {
+    string l_cmd = xtd::format::vargs("wget -q -O/dev/null http://localhost:%d/bar", m_port);
+    exec(l_cmd, 0, __FILE__, __LINE__);
+  }
+
+  {
+    // specific handlers have precedence on wildcar handlers
+    string l_cmd = xtd::format::vargs("wget -q -O/dev/null http://localhost:%d/test", m_port);
+    exec(l_cmd, 8, __FILE__, __LINE__);
+  }
+}
+
+void
+TestHttpServer::expiredConnection(void)
+{
+  xtd::network::utils::Config          l_conf;
+  Client<xtd::network::utils::af_inet> l_client(l_conf);
+  string   l_value;
+
+  Request  l_req;
+  Response l_res;
+  l_req.setPath("/");
+  l_req.setMethod(method::get);
+  l_req.setVersion(version::v1_0);
+
+  // simple 1.0 request, no server keep alive
+  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.connect("localhost", m_port));
+  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.send(l_req));
+  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.receive(l_res));
+  CPPUNIT_ASSERT_EQUAL(false,           l_res.getHeader("Keep-Alive", l_value));
+  l_client.close();
+
+  l_res = Response();
+  l_req.setVersion(version::v1_1);
+  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.connect("localhost", m_port));
+  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.send(l_req));
+  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.receive(l_res));
+  // this time server let the cnx open
+  CPPUNIT_ASSERT_EQUAL(true,            l_res.getHeader("Keep-Alive", l_value));
+  CPPUNIT_ASSERT_EQUAL(string("timeout=1, max=100"), l_value);
+
+  l_res = Response();
+  // we can resend a request on same cnx
+  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.send(l_req));
+  CPPUNIT_ASSERT_EQUAL(xtd::status::ok, l_client.receive(l_res));
+  CPPUNIT_ASSERT_EQUAL(string("timeout=1, max=100"), l_value);
+
+  l_res = Response();
+  // delay is expired, server should have closed the cnx
+  boost::this_thread::sleep(boost::posix_time::milliseconds(2000));
+  CPPUNIT_ASSERT_EQUAL(xtd::status::ok,    l_client.send(l_req));
+  CPPUNIT_ASSERT_EQUAL(xtd::status::error, l_client.receive(l_res));
+}
+
+XTD_TEST_MAIN();
+
+
+// Local Variables:
+// ispell-local-dictionary: "en"
+// End:

--- a/servers/src/app/HttpServer.cc
+++ b/servers/src/app/HttpServer.cc
@@ -403,16 +403,16 @@ HttpServer::h_probe(const uint32_t                /*p_requestID*/,
                     const http::Request& p_req,
                     http::Response&      p_res)
 {
-  p_res.setVersion(p_req.getVersionStr());
+  p_res.setVersion(p_req.getVersion());
   if (true == m_isModeProbe)
   {
     p_res.setStatus(http::code::service_unavailable);
-    p_res.setData(http::Response::statusToMessage(http::code::service_unavailable));
+    p_res.setData(http::str(http::code::service_unavailable));
   }
   else
   {
     p_res.setStatus(http::code::ok);
-    p_res.setData(http::Response::statusToMessage(http::code::ok));
+    p_res.setData(http::str(http::code::ok));
   }
   return status::ok;
 }

--- a/servers/src/app/HttpServer.cc
+++ b/servers/src/app/HttpServer.cc
@@ -29,10 +29,10 @@ namespace servers {
 namespace app {
 
 using namespace network;
-using namespace boost;
+
 namespace       bfs = boost::filesystem;
 namespace       ba  = boost::algorithm;
-namespace       bpt = boost::property_tree;
+namespace       bpt = boost::posix_time;
 
 const char HttpServer::mcs_defaultListenInterface[] = "0.0.0.0";
 
@@ -64,8 +64,8 @@ HttpServer::HttpServer(bool p_isDebug) :
   addOption('t', "timeout",     argument::mandatory, requirement::optional,  "server timeout in ms",                           bindNumber(m_timeoutMs));
 
   m_httpConfig.setReuseAddr(true);
-  addSignalHandler(SIGUSR2, boost::bind(&HttpServer::handleUSR2, this));
-  addSignalHandler(SIGTERM, boost::bind(&HttpServer::handleTERM, this));
+  addSignalHandler(SIGUSR2, std::bind(&HttpServer::handleUSR2, this));
+  addSignalHandler(SIGTERM, std::bind(&HttpServer::handleTERM, this));
 }
 
 HttpServer::~HttpServer(void)
@@ -113,8 +113,8 @@ HttpServer::parseConfig(void)
       error_nohelp(1, "option --config-file is mandatory");
     }
 
-    if ((false == boost::filesystem::is_regular_file(m_configPath)) &&
-        (false == boost::filesystem::is_symlink(m_configPath)))
+    if ((false == bfs::is_regular_file(m_configPath)) &&
+        (false == bfs::is_symlink(m_configPath)))
     {
       error_nohelp(1, "invalid --config-file='%s' option, file unreadable", m_configPath);
     }
@@ -185,7 +185,7 @@ HttpServer::parseConfig(void)
 void
 HttpServer::parseHttpPort(void)
 {
-  string l_key = boost::str(boost::format("%s:server:http:port") % getSpecificConfKey());
+  string l_key = format::vargs("%s:server:http:port", getSpecificConfKey());
   readConf(l_key, m_httpPort);
 }
 
@@ -247,13 +247,13 @@ HttpServer::initialize(void)
   m_params.reset(new param::Handler(m_adminDir));
 
   // Link admin console contexts
-  bind_public("/admin",    h(&HttpServer::h_admin,      this), "administration");
+  bind_public("/admin",    h(&HttpServer::h_admin, this),      "administration");
   bind_public("/action",   h(&HttpServer::h_actionList, this), "actions");
-  bind_public("/counter*", h(&HttpServer::h_counter,    this), "counters");
-  bind_public("/conf",     h(&HttpServer::h_conf,       this), "configuration");
-  bind_public("/ident",    h(&HttpServer::h_ident,      this), "identity");
-  bind_public("/log",      h(&HttpServer::h_log,        this), "logs");
-  bind_public("/index",    h(&HttpServer::h_index,      this), "index");
+  bind_public("/counter*", h(&HttpServer::h_counter, this),    "counters");
+  bind_public("/conf",     h(&HttpServer::h_conf, this),       "configuration");
+  bind_public("/ident",    h(&HttpServer::h_ident, this),      "identity");
+  bind_public("/log",      h(&HttpServer::h_log, this),        "logs");
+  bind_public("/index",    h(&HttpServer::h_index, this),      "index");
 
 
   bind_dir("/css/images/*", m_httpConfigPath + "/css/images", "images/png",      true);
@@ -318,7 +318,7 @@ void HttpServer::modeProbeActivation(void)
 void
 HttpServer::bind_action(const string& p_name,
                         const string& p_description,
-                        h             p_action)
+                        handler       p_action)
 {
   t_action l_action(new Action(p_name, p_description));
 
@@ -328,7 +328,7 @@ HttpServer::bind_action(const string& p_name,
 
 status
 HttpServer::h_runAction(const string&        p_name,
-                        h                    p_action,
+                        handler              p_action,
                         const uint32_t       p_requestID,
                         const http::Request& p_req,
                         http::Response&      p_res)
@@ -357,7 +357,7 @@ HttpServer::h_runAction(const string&        p_name,
     {
       l_status = "DONE";
       p_res.setStatus(http::code::ok);
-      c_action->second->m_timestamp = boost::posix_time::microsec_clock::local_time();
+      c_action->second->m_timestamp = bpt::microsec_clock::local_time();
       c_action->second->m_log       = l_log;
     }
     log::crit("servers.app.http", "action '%s' - execution status : %s", p_name, l_status, HERE);
@@ -392,7 +392,7 @@ HttpServer::h_actionList(const uint32_t       p_requestID,
     tm     l_tm = to_tm(cc_value.second->m_timestamp);
     time_t l_date = mktime(&l_tm);
 
-    l_tmpl.add(cc_value.first, "timestamp", lexical_cast<uint32_t>(l_date));
+    l_tmpl.add(cc_value.first, "timestamp", boost::lexical_cast<uint32_t>(l_date));
   }
 
   return h_gen(l_tmpl, p_requestID, p_req, p_res);
@@ -456,16 +456,16 @@ HttpServer::h_index(const uint32_t       p_requestID,
 
   std::sort(l_list.begin(),
             l_list.end(),
-            boost::bind(std::less<string>(),
-                        boost::bind(&Handler::m_descr, _2),
-                        boost::bind(&Handler::m_descr, _1)));
+            std::bind(std::less<string>(),
+                      std::bind(&Handler::m_descr, std::placeholders::_2),
+                      std::bind(&Handler::m_descr, std::placeholders::_1)));
 
-  BOOST_FOREACH(const Handler& c_handler, l_list)
+  for(const Handler& c_handler : l_list)
   {
     string          l_url = c_handler.m_path;
     Template::t_map l_link;
 
-    trim_right_if(l_url, is_any_of("*"));
+    trim_right_if(l_url, boost::is_any_of("*"));
     l_link["link"] = Template::val(l_url);
     l_link["text"] = Template::val(c_handler.m_descr);
     l_links.push_back(Template::val(l_link));
@@ -535,6 +535,8 @@ HttpServer::h_counter(const uint32_t       /* p_requestID */,
                       const http::Request&    p_req,
                       http::Response&         p_res)
 {
+  using namespace boost::property_tree;
+
   uint32_t     l_vmUsage;
   uint32_t     l_residentSet;
   stringstream l_responseData;
@@ -544,13 +546,13 @@ HttpServer::h_counter(const uint32_t       /* p_requestID */,
   (*m_ramCounter) = l_residentSet;
 
   // 2.
-  bpt::ptree l_elements;
-  bpt::ptree l_root;
-  string     l_subPath = p_req.getPath();
+  ptree  l_elements;
+  ptree  l_root;
+  string l_subPath = p_req.getPath();
 
   ba::replace_all(l_subPath, "/", "!");
   ba::trim_if(l_subPath, ba::is_any_of("!"));
-  bpt::ptree::path_type l_subPathType(l_subPath, '!');
+  ptree::path_type l_subPathType(l_subPath, '!');
 
   // Gets json tree representation of counters from prober
   m_prober->toJson(l_elements);
@@ -558,17 +560,17 @@ HttpServer::h_counter(const uint32_t       /* p_requestID */,
   try
   {
     l_root.put_child("counter", l_elements);
-    bpt::ptree l_child = l_root.get_child(l_subPathType);
+    ptree l_child = l_root.get_child(l_subPathType);
     write_json(l_responseData, l_child);
     p_res.setData(l_responseData.str());
     p_res.addHeader("Content-Type", "application/json");
     p_res.setStatus(http::code::ok);
   }
-  catch (bpt::file_parser_error&)
+  catch (file_parser_error&)
   {
     string           l_name = l_subPath.substr(l_subPath.find_last_of("!")+1);
-    bpt::ptree::path_type l_namePathType(l_name, '!');
-    bpt::ptree            l_node;
+    ptree::path_type l_namePathType(l_name, '!');
+    ptree            l_node;
 
     l_node.put<string>(l_namePathType, l_root.get<string>(l_subPathType));
     write_json(l_responseData, l_node);
@@ -576,7 +578,7 @@ HttpServer::h_counter(const uint32_t       /* p_requestID */,
     p_res.addHeader("Content-Type", "application/json");
     p_res.setStatus(http::code::ok);
   }
-  catch (bpt::ptree_bad_path&)
+  catch (ptree_bad_path&)
   {
     l_responseData << p_req.getPath() << " not found" << endl;
     p_res.setData(l_responseData.str());

--- a/servers/src/app/HttpServer.hh
+++ b/servers/src/app/HttpServer.hh
@@ -99,10 +99,10 @@ protected:
 
   void bind_action(const string& p_name,
                    const string& p_description,
-                   h                  p_action);
+                   handler       p_action);
 
   status h_runAction(const string&                 p_name,
-                     h                             p_action,
+                     handler                       p_action,
                      const uint32_t                p_requestId,
                      const network::http::Request& p_req,
                      network::http::Response&      p_res);

--- a/servers/src/app/Server.hxx
+++ b/servers/src/app/Server.hxx
@@ -302,12 +302,13 @@ Server<TReq, TRes, Domain>::initialize(void)
   bip_app::m_perfCounter.reset(new counters::AvgTimedValue("", m_nbThread, 60000, m_thresholdMs));
 
   bind("/query_data",
-       h(&bip_app::h_query,      this),
+       h(&bip_app::h_query, this),
        f(&bip_app::f_post_exist, this, "xml"));
 
   bind_public("/query",
               h(&bip_app::h_ihm_query, this),
               "[IHM] génération de requête");
+
   //! Parameters
   m_params->add("assertRTT", m_assertRTT, true)
     ->listen<bool>(boost::bind(&bip_app::setAssertRTT, this, _2));

--- a/tests/src/MainTestApplication.cc
+++ b/tests/src/MainTestApplication.cc
@@ -12,7 +12,7 @@
 #include <cppunit/ui/text/TestRunner.h>  // libcppunit
 #include <cppunit/TestResultCollector.h>
 #include <boost/regex.hpp>
-
+#include <log/ConfLoader.hh>
 
 namespace xtd {
 namespace tests {
@@ -72,6 +72,20 @@ MainTestApplication::createOutputter(CppUnit::TestResultCollector& p_result, std
   if (m_ouputter == "text")
     return new CppUnit::XmlOutputter(&p_result, p_stream, "UTF-8");
   return new CppUnit::TextOutputter(&p_result, p_stream);
+}
+
+
+void
+MainTestApplication::initialize(void)
+{
+  auto& l_logger = log::ConfLoader::get();
+
+  l_logger.configure({
+      { "log.logger.root",             "DEBUG, A1"       },
+      { "log.appender.A1.class",       "SyslogAppender"  },
+      { "log.appender.syslog.options", "LOG_PID"         },
+      { "log.appender.A1.facility",    "LOG_LOCAL0"      }
+    });
 }
 
 /**

--- a/tests/src/MainTestApplication.hh
+++ b/tests/src/MainTestApplication.hh
@@ -19,11 +19,12 @@ class MainTestApplication : public Application
 public:
   MainTestApplication(void);
 
-private:
-  int process(void);
 
-  CppUnit::Outputter*
-  createOutputter(CppUnit::TestResultCollector& p_result, std::ostream& p_stream) const;
+private:
+  int  process(void);
+  void initialize(void);
+
+  CppUnit::Outputter* createOutputter(CppUnit::TestResultCollector& p_result, std::ostream& p_stream) const;
 
 protected:
   string m_filter;

--- a/tests/src/TestFixture.cc
+++ b/tests/src/TestFixture.cc
@@ -30,4 +30,13 @@ TestFixture::getFileContent(const string& p_path, const char* p_file, int p_line
   return l_result;
 }
 
+void
+TestFixture::exec(const std::string& p_cmd, int p_status, const char* p_file, int p_line) const
+{
+  int l_status = system(p_cmd.c_str());
+  CPPUNIT_ASSERT_AT(WIFEXITED(l_status), p_file, p_line);
+  CPPUNIT_ASSERT_EQUAL_AT(p_status,  WEXITSTATUS(l_status), p_file, p_line);
+}
+
+
 }}

--- a/tests/src/TestFixture.hh
+++ b/tests/src/TestFixture.hh
@@ -16,6 +16,7 @@ protected:
 
 protected:
   string getFileContent(const string& p_path, const char* p_file, int p_line) const;
+  void   exec(const std::string& p_cmd, int p_status, const char* p_file, int p_line) const;
 };
 
 }}

--- a/travis-ci/Dockerfile
+++ b/travis-ci/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update && apt-get install -y --force-yes \
     plantuml \
     valgrind \
     git \
-    zlib1g-dev
+    zlib1g-dev \
+    wget
 RUN pip3 install coverxygen
 RUN pip3 install lxml
 RUN pip3 install requests

--- a/travis-ci/Dockerfile
+++ b/travis-ci/Dockerfile
@@ -18,6 +18,10 @@ RUN apt-get update && apt-get install -y --force-yes \
     git \
     zlib1g-dev \
     wget
+RUN apt-get update && apt-get install -y --force-yes python-pip netcat-openbsd
 RUN pip3 install coverxygen
 RUN pip3 install lxml
 RUN pip3 install requests
+RUN pip install coverxygen
+RUN pip install lxml
+RUN pip install requests


### PR DESCRIPTION
* [network/http] fixes #19 : boost and std shared_pointer are no longer mixed
* [network/http] fixes #20 : server replies with correct keepalive heaver
* [network/http] implements http client
* [network/http] get rid of ugly filter and handler structures replaced by c++11 variadic template args
* [network] replace many boost call to c++11 std
* [core] log config loader parses log_level case insensitively
* [core] log syslogappender no longer require options config property
* [core] moved url decode function to core text::url
* [tests] enable debug syslog logs in main test application
* [tests] adds handy "exec" function to default test fixture class
* xtdmake : bump version